### PR TITLE
Fix ACP connections being shared across personas

### DIFF
--- a/jupyter_ai_acp_client/acp_personas/test.py
+++ b/jupyter_ai_acp_client/acp_personas/test.py
@@ -1,10 +1,15 @@
 import os
+import sys
 from ..base_acp_persona import BaseAcpPersona
 from jupyter_ai_persona_manager import PersonaDefaults
 
 class TestAcpPersona(BaseAcpPersona):
     def __init__(self, *args, **kwargs):
-        executable = ["python", "jupyter-ai-acp-client/examples/agent.py"]
+        # Get absolute path to agent.py
+        agent_path = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "..", "examples", "agent.py")
+        )
+        executable = [sys.executable, agent_path]
         super().__init__(*args, executable=executable, **kwargs)
     
     @property


### PR DESCRIPTION
The @Test-ACP persona does not return a response because it is conflated with the subprocess for the @Claude-ACP persona. Since the Claude-ACP persona is started up first when Jupyter is initiated, this subprocess was the only one being started and the @Test-ACP persona was using this subprocess. The code edits ensure that each `@*-ACP` persona has its own subprocess. 

After the fix, the personas work as intended as shown below : 
<img width="670" height="606" alt="acp" src="https://github.com/user-attachments/assets/e68b670c-192f-48ce-8f1b-0d38f7ebd4e0" />
