### PR TITLE
Bump jupyterlab_chat to >=0.20.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 dependencies = [
     "jupyter_server>=2.4.0,<3",
     "jupyter_ai_persona_manager>=0.0.6",
-    "jupyterlab_chat>=0.20.0a2",
+    "jupyterlab_chat>=0.20.0",
     "agent_client_protocol",
     "pydantic>=2,<3",
 ]


### PR DESCRIPTION
Bump to a non-pre-release version as no Conda Forge releases exist for pre-release versions.