### PR TITLE
Raise stream buffer limit from 64 KiB to 50 MiB

### DIFF
--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -97,6 +97,7 @@ class BaseAcpPersona(BasePersona):
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=sys.stderr,
+            limit=50 * 1024 * 1024,
         )
         self.log.info(f"Spawned ACP agent subprocess for '{self.__class__.__name__}'.")
         return process


### PR DESCRIPTION
Closes #32 

This adds` limit=50 * 1024 * 1024 (50MB)` to the create_subprocess_exec call in _init_agent_subprocess(), matching the ACP SDK's DEFAULT_STDIO_BUFFER_LIMIT_BYTES convention. The ACP SDK already applies this limit on the agent side, but not on the client side. Since we create the subprocess ourselves, we need to set it here.