### PR TITLE
Provide accurate Kiro login instructions in headless environments

### DIFF
--- a/jupyter_ai_acp_client/acp_personas/kiro.py
+++ b/jupyter_ai_acp_client/acp_personas/kiro.py
@@ -150,7 +150,7 @@ class KiroAcpPersona(BaseAcpPersona):
         return process.returncode == 0
     
     async def _should_use_device_flow(self) -> bool:
-        """Check if device flow should be used on Linux. Based on Kiro CLI remote detection."""
+        """Check if device flow should be used on Linux."""
         try:
             if platform.system() != 'Linux':
                 return False
@@ -158,10 +158,14 @@ class KiroAcpPersona(BaseAcpPersona):
             # Check SSH
             if any(var in os.environ for var in ['SSH_CLIENT', 'SSH_CONNECTION', 'SSH_TTY']):
                 return True
-
-            with open('/proc/sys/kernel/osrelease', 'r') as f:
-                if any(x in f.read().lower() for x in ['microsoft', 'wsl']):
-                    return not shutil.which('wslview')
+            
+            # Check WSL
+            try:
+                with open('/proc/sys/kernel/osrelease', 'r') as f:
+                    if any(x in f.read().lower() for x in ['microsoft', 'wsl']):
+                        return not shutil.which('wslview')
+            except:
+                pass
             
             # Check xdg-open
             return not shutil.which('xdg-open')


### PR DESCRIPTION
### Auto-detect device flow requirement for Kiro login on Linux

- Closes #23.

Problem: When users aren't authenticated with Kiro in environments where browser opening fails (SSH sessions, WSL without wslview, Linux without xdg-open), the login message instructs them to run 
kiro-cli login, which then fails with "No such file or directory" error.

Solution: Automatically detect when device flow is needed and show the correct command (kiro-cli login --use-device-flow) in the authentication message.

### Changes

File: jupyter_ai_acp_client/acp_personas/kiro.py

1. Added platform import
2. Added _should_use_device_flow() method that detects:
   - SSH sessions (via environment variables)
   - WSL without wslview 
   - Linux without xdg-open
3. Updated handle_no_auth() to use detected command in user message

### Behavior

- **Linux in SSH**: Shows kiro-cli login --use-device-flow
- **WSL without wslview**: Shows kiro-cli login --use-device-flow
- **Linux without xdg-open**: Shows kiro-cli login --use-device-flow
- **macOS/Windows/Linux with browser**: Shows kiro-cli login

Detection failures gracefully fall back to standard login command with warning logged.