### PR TITLE
feat: deserialize YChat attachments to typed dataclasses

### DIFF
--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -2,15 +2,79 @@ import asyncio
 import sys
 from asyncio import Task
 from asyncio.subprocess import Process
+from dataclasses import fields as dataclass_fields
 from typing import Awaitable, ClassVar
 
 from acp import NewSessionResponse, LoadSessionResponse
 from acp.schema import AvailableCommand
 from jupyter_ai_persona_manager import BasePersona
-from jupyterlab_chat.models import Message
+from jupyterlab_chat.models import (
+    AttachmentSelection,
+    FileAttachment,
+    Message,
+    NotebookAttachment,
+    NotebookAttachmentCell,
+)
 
 from .default_acp_client import JaiAcpClient
 
+
+def _reconstruct_selection(raw: dict) -> AttachmentSelection | None:
+    """Reconstruct an AttachmentSelection, converting CRDT lists to tuples."""
+    start = raw.get("start")
+    end = raw.get("end")
+    content = raw.get("content")
+    if start is None or end is None or content is None:
+        return None
+    return AttachmentSelection(
+        start=tuple(start) if isinstance(start, list) else start,
+        end=tuple(end) if isinstance(end, list) else end,
+        content=content,
+    )
+
+
+def _deserialize_attachment(raw: dict) -> FileAttachment | NotebookAttachment | None:
+    """Convert a raw dict from YChat into a typed attachment dataclass.
+
+    YChat stores attachments as plain dicts (via ``dataclasses.asdict()`` →
+    pycrdt Map → ``to_py()``).  This rebuilds the original dataclass,
+    filtering unknown keys for forward-compatibility.
+    """
+    att_type = raw.get("type")
+    if att_type == "file":
+        cls = FileAttachment
+    elif att_type == "notebook":
+        cls = NotebookAttachment
+    else:
+        return None
+
+    accepted_keys = {f.name for f in dataclass_fields(cls)}
+    filtered = {k: v for k, v in raw.items() if k in accepted_keys}
+
+    # Reconstruct nested AttachmentSelection
+    if isinstance(filtered.get("selection"), dict):
+        filtered["selection"] = _reconstruct_selection(filtered["selection"])
+
+    # Reconstruct nested NotebookAttachmentCell list
+    if isinstance(filtered.get("cells"), list):
+        cell_keys = {f.name for f in dataclass_fields(NotebookAttachmentCell)}
+        reconstructed = []
+        for raw_cell in filtered["cells"]:
+            if not isinstance(raw_cell, dict):
+                continue
+            cell_data = {k: v for k, v in raw_cell.items() if k in cell_keys}
+            if isinstance(cell_data.get("selection"), dict):
+                cell_data["selection"] = _reconstruct_selection(cell_data["selection"])
+            try:
+                reconstructed.append(NotebookAttachmentCell(**cell_data))
+            except TypeError:
+                continue
+        filtered["cells"] = reconstructed or None
+
+    try:
+        return cls(**filtered)
+    except TypeError:
+        return None
 
 
 class BaseAcpPersona(BasePersona):
@@ -27,7 +91,7 @@ class BaseAcpPersona(BasePersona):
     The task that yields the agent subprocess once complete. This is a class
     attribute because multiple instances of the same ACP persona may share an
     ACP agent subprocess.
-    
+
     Developers should always use `self.get_agent_subprocess()`.
     """
 
@@ -87,7 +151,7 @@ class BaseAcpPersona(BasePersona):
 
         The `BaseAcpPersona` does not implement this method by default.
         Subclasses are expected to provide a custom implementation of this
-        method if required. 
+        method if required.
         """
         return None
 
@@ -109,7 +173,7 @@ class BaseAcpPersona(BasePersona):
         client = JaiAcpClient(agent_subprocess=agent_subprocess, event_loop=self.event_loop)
         self.log.info("Initialized ACP client for '%s'.", self.__class__.__name__)
         return client
-    
+
     def _get_existing_sessions(self) -> dict[str, str]:
         """
         Returns a dictionary of existing ACP session IDs within this instance's
@@ -120,7 +184,7 @@ class BaseAcpPersona(BasePersona):
         """
         sessions = self.ychat.get_metadata().get("acp_session_ids", {})
         return sessions
-    
+
     def _record_new_session(self, new_session_id: str) -> None:
         """
         Adds a new ACP session ID into this chat's metadata. Always use this
@@ -167,19 +231,19 @@ class BaseAcpPersona(BasePersona):
         Safely returns the ACP agent subprocess for this persona.
         """
         return await self.__class__._subprocess_future
-    
+
     async def get_client(self) -> JaiAcpClient:
         """
         Safely returns the ACP client for this persona.
         """
         return await self.__class__._client_future
-    
+
     async def get_session_response(self) -> NewSessionResponse | LoadSessionResponse:
         """
         Safely returns the ACP session response for this chat.
         """
         return await self._client_session_future
-    
+
     async def get_session_id(self) -> str:
         """
         Safely returns the ACP session ID assigned to this chat.
@@ -190,14 +254,14 @@ class BaseAcpPersona(BasePersona):
         session_ids =  self._get_existing_sessions()
         assert self.id in session_ids
         return session_ids[self.id]
-    
+
     async def is_authed(self) -> bool:
         """
         Returns whether the client is authenticated to use this agent. Returns
         `True` by default. Subclasses should override this if possible.
         """
         return True
-    
+
     async def handle_no_auth(self, message: Message) -> None:
         """
         Method called when the persona receives a message while the user is not
@@ -206,7 +270,7 @@ class BaseAcpPersona(BasePersona):
         customize the help message sent.
         """
         self.send_message("You are not authenticated. Please log in.")
-    
+
     async def process_message(self, message: Message) -> None:
         """
         A default implementation for the `BasePersona.process_message()` method
@@ -224,17 +288,23 @@ class BaseAcpPersona(BasePersona):
 
         prompt = message.body.replace("@" + self.as_user().mention_name, "").strip()
 
-        # Resolve attachments from YChat by ID
-        attachments: list[dict] | None = None
+        # Resolve attachments from YChat by ID and deserialize to typed dataclasses
+        attachments: list[FileAttachment | NotebookAttachment] | None = None
         if message.attachments:
             all_attachments = self.ychat.get_attachments()
-            resolved = []
+            resolved: list[FileAttachment | NotebookAttachment] = []
             for aid in message.attachments:
                 raw = all_attachments.get(aid)
                 if raw is None:
                     self.log.warning("Attachment %s not found in YChat", aid)
                     continue
-                resolved.append(raw)
+                att = _deserialize_attachment(raw)
+                if att is None:
+                    self.log.warning(
+                        "Cannot deserialize attachment %s (type=%s)", aid, raw.get("type")
+                    )
+                    continue
+                resolved.append(att)
             attachments = resolved or None
 
         await client.prompt_and_reply(
@@ -243,7 +313,7 @@ class BaseAcpPersona(BasePersona):
             attachments=attachments,
             root_dir=self.parent.root_dir,
         )
-    
+
     @property
     def acp_slash_commands(self) -> list[AvailableCommand]:
         """
@@ -255,7 +325,7 @@ class BaseAcpPersona(BasePersona):
         `AvailableCommandsUpdate` payload from the ACP agent.
         """
         return self._acp_slash_commands
-    
+
     @acp_slash_commands.setter
     def acp_slash_commands(self, commands: list[AvailableCommand]):
         self.log.info(

--- a/jupyter_ai_acp_client/default_acp_client.py
+++ b/jupyter_ai_acp_client/default_acp_client.py
@@ -53,7 +53,7 @@ from acp.schema import (
     DeniedOutcome
 )
 from jupyter_ai_persona_manager import BasePersona, McpServerStdio
-from jupyterlab_chat.models import Message
+from jupyterlab_chat.models import FileAttachment, Message, NotebookAttachment
 from jupyterlab_chat.utils import find_mentions
 from asyncio.subprocess import Process
 
@@ -63,6 +63,42 @@ from .tool_call_renderer import ensure_serializable, extract_diffs
 from .permission_manager import PermissionManager
 
 import traceback as tb_mod
+
+def _build_attachment_description(
+    att: FileAttachment | NotebookAttachment,
+) -> str | None:
+    """Build a human-readable description from attachment selection/cell info.
+
+    CodeMirror positions are 0-indexed; this function converts to 1-indexed
+    for human display.
+    """
+    if isinstance(att, FileAttachment):
+        if att.selection is None:
+            return None
+        start_line = att.selection.start[0] + 1
+        end_line = att.selection.end[0] + 1
+        if start_line == end_line:
+            return f"Line {start_line}"
+        return f"Lines {start_line}-{end_line}"
+
+    if isinstance(att, NotebookAttachment):
+        if not att.cells:
+            return None
+        parts: list[str] = []
+        for cell in att.cells:
+            if cell.selection is not None:
+                start_line = cell.selection.start[0] + 1
+                end_line = cell.selection.end[0] + 1
+                if start_line == end_line:
+                    parts.append(f'Cell "{cell.id}" (line {start_line})')
+                else:
+                    parts.append(f'Cell "{cell.id}" (lines {start_line}-{end_line})')
+            else:
+                parts.append(f'Cell "{cell.id}"')
+        return f"Selected cells: {', '.join(parts)}"
+
+    return None
+
 
 class JaiAcpClient(Client):
     """
@@ -218,11 +254,12 @@ class JaiAcpClient(Client):
         self._personas_by_session[session_id] = persona
         return response
 
+
     async def prompt_and_reply(
         self,
         session_id: str,
         prompt: str,
-        attachments: list[dict] | None = None,
+        attachments: list[FileAttachment | NotebookAttachment] | None = None,
         root_dir: str | None = None,
     ) -> PromptResponse:
         """
@@ -260,33 +297,28 @@ class JaiAcpClient(Client):
 
             try:
                 # Build content blocks: text prompt + optional attachment resources
-                content_blocks: list[TextContentBlock | ResourceContentBlock] = [
-                    TextContentBlock(text=prompt, type="text"),
-                ]
+                content_blocks = [TextContentBlock(text=prompt, type="text")]
+
                 if attachments:
                     for att in attachments:
-                        att_value = att.get("value", "")
-                        att_type = att.get("type", "file")
+                        att_value = att.value
+                        mime_type = getattr(att, "mimetype", None)
 
-                        # Resolve to absolute file:// URI when root_dir is available
+                        # Resolve file:// URI from root_dir
+                        uri = att_value
                         if root_dir and att_value:
                             abs_path = (Path(root_dir) / att_value).resolve()
                             root_resolved = Path(root_dir).resolve()
                             if not abs_path.is_relative_to(root_resolved):
                                 persona.log.warning(
-                                    "Attachment path %r escapes root_dir %r",
-                                    att_value,
-                                    root_dir,
+                                    "Attachment path %s escapes root_dir %s",
+                                    att_value, root_dir,
                                 )
-                                uri = att_value
                             else:
                                 uri = abs_path.as_uri()
-                        else:
-                            uri = att_value
 
-                        # Determine MIME type: explicit value or notebook default
-                        mime_type = att.get("mimetype")
-                        if mime_type is None and att_type == "notebook":
+                        # Default notebook MIME type
+                        if isinstance(att, NotebookAttachment) and not mime_type:
                             mime_type = "application/x-ipynb+json"
 
                         content_blocks.append(
@@ -295,6 +327,7 @@ class JaiAcpClient(Client):
                                 name=Path(att_value).name if att_value else "<attachment>",
                                 type="resource_link",
                                 mime_type=mime_type,
+                                description=_build_attachment_description(att),
                             )
                         )
 

--- a/jupyter_ai_acp_client/tests/test_base_acp_persona.py
+++ b/jupyter_ai_acp_client/tests/test_base_acp_persona.py
@@ -2,7 +2,17 @@
 
 from unittest.mock import AsyncMock, MagicMock
 
-from jupyter_ai_acp_client.base_acp_persona import BaseAcpPersona
+from jupyterlab_chat.models import (
+    AttachmentSelection,
+    FileAttachment,
+    NotebookAttachment,
+    NotebookAttachmentCell,
+)
+
+from jupyter_ai_acp_client.base_acp_persona import (
+    BaseAcpPersona,
+    _deserialize_attachment,
+)
 
 
 def _make_persona(attachments_map: dict | None = None):
@@ -63,7 +73,7 @@ class TestProcessMessageAttachments:
         )
 
     async def test_single_attachment(self):
-        """A single known attachment ID resolves to a dict."""
+        """A single known attachment ID resolves to a FileAttachment."""
         client = _make_client()
         att_map = {
             "att-1": {"value": "file.py", "type": "file", "mimetype": "text/x-python"},
@@ -75,10 +85,14 @@ class TestProcessMessageAttachments:
         await BaseAcpPersona.process_message(persona, msg)
 
         call_kwargs = client.prompt_and_reply.call_args.kwargs
-        assert call_kwargs["attachments"] == [att_map["att-1"]]
+        atts = call_kwargs["attachments"]
+        assert len(atts) == 1
+        assert isinstance(atts[0], FileAttachment)
+        assert atts[0].value == "file.py"
+        assert atts[0].mimetype == "text/x-python"
 
     async def test_multiple_attachments(self):
-        """Multiple attachment IDs all resolve in order."""
+        """Multiple attachment IDs all resolve in order as typed dataclasses."""
         client = _make_client()
         att_map = {
             "att-1": {"value": "a.py", "type": "file"},
@@ -91,7 +105,12 @@ class TestProcessMessageAttachments:
         await BaseAcpPersona.process_message(persona, msg)
 
         call_kwargs = client.prompt_and_reply.call_args.kwargs
-        assert call_kwargs["attachments"] == [att_map["att-1"], att_map["att-2"]]
+        atts = call_kwargs["attachments"]
+        assert len(atts) == 2
+        assert isinstance(atts[0], FileAttachment)
+        assert isinstance(atts[1], NotebookAttachment)
+        assert atts[0].value == "a.py"
+        assert atts[1].value == "b.ipynb"
 
     async def test_unknown_attachment_id_skipped(self):
         """Unknown attachment IDs are silently skipped with a log warning."""
@@ -116,7 +135,10 @@ class TestProcessMessageAttachments:
         await BaseAcpPersona.process_message(persona, msg)
 
         call_kwargs = client.prompt_and_reply.call_args.kwargs
-        assert call_kwargs["attachments"] == [att_map["att-1"]]
+        atts = call_kwargs["attachments"]
+        assert len(atts) == 1
+        assert isinstance(atts[0], FileAttachment)
+        assert atts[0].value == "good.py"
 
     async def test_empty_attachment_list(self):
         """An empty attachment list results in None."""
@@ -142,3 +164,123 @@ class TestProcessMessageAttachments:
 
         call_kwargs = client.prompt_and_reply.call_args.kwargs
         assert call_kwargs["root_dir"] == "/custom/root"
+
+    async def test_unknown_type_skipped(self):
+        """Attachments with unrecognized type are skipped with a warning."""
+        client = _make_client()
+        att_map = {"att-1": {"value": "x", "type": "unknown_type"}}
+        persona = _make_persona(att_map)
+        persona.get_client.return_value = client
+        msg = _make_message("@bot check", ["att-1"])
+
+        await BaseAcpPersona.process_message(persona, msg)
+
+        call_kwargs = client.prompt_and_reply.call_args.kwargs
+        assert call_kwargs["attachments"] is None
+        persona.log.warning.assert_called()
+
+
+class TestDeserializeAttachment:
+    """Tests for _deserialize_attachment helper."""
+
+    def test_file_attachment(self):
+        raw = {"value": "main.py", "type": "file", "mimetype": "text/x-python"}
+        result = _deserialize_attachment(raw)
+        assert isinstance(result, FileAttachment)
+        assert result.value == "main.py"
+        assert result.mimetype == "text/x-python"
+
+    def test_notebook_attachment(self):
+        raw = {"value": "analysis.ipynb", "type": "notebook"}
+        result = _deserialize_attachment(raw)
+        assert isinstance(result, NotebookAttachment)
+        assert result.value == "analysis.ipynb"
+
+    def test_unknown_type_returns_none(self):
+        raw = {"value": "x", "type": "unknown"}
+        assert _deserialize_attachment(raw) is None
+
+    def test_missing_type_returns_none(self):
+        raw = {"value": "x"}
+        assert _deserialize_attachment(raw) is None
+
+    def test_unknown_keys_filtered(self):
+        """Forward-compat: unknown keys from future schema versions are dropped."""
+        raw = {"value": "x.py", "type": "file", "future_field": "ignored"}
+        result = _deserialize_attachment(raw)
+        assert isinstance(result, FileAttachment)
+        assert not hasattr(result, "future_field")
+
+    def test_file_with_selection(self):
+        """AttachmentSelection is reconstructed with tuples from CRDT lists."""
+        raw = {
+            "value": "main.py",
+            "type": "file",
+            "selection": {"start": [5, 0], "end": [10, 0], "content": "hello"},
+        }
+        result = _deserialize_attachment(raw)
+        assert isinstance(result, FileAttachment)
+        assert isinstance(result.selection, AttachmentSelection)
+        assert result.selection.start == (5, 0)
+        assert result.selection.end == (10, 0)
+        assert result.selection.content == "hello"
+
+    def test_selection_with_native_tuples(self):
+        """Tuples that survived without CRDT round-trip are preserved."""
+        raw = {
+            "value": "main.py",
+            "type": "file",
+            "selection": {"start": (2, 3), "end": (4, 5), "content": "x"},
+        }
+        result = _deserialize_attachment(raw)
+        assert result.selection.start == (2, 3)
+
+    def test_notebook_with_cells(self):
+        raw = {
+            "value": "nb.ipynb",
+            "type": "notebook",
+            "cells": [
+                {"id": "cell-1", "input_type": "code"},
+                {"id": "cell-2", "input_type": "markdown"},
+            ],
+        }
+        result = _deserialize_attachment(raw)
+        assert isinstance(result, NotebookAttachment)
+        assert len(result.cells) == 2
+        assert isinstance(result.cells[0], NotebookAttachmentCell)
+        assert result.cells[0].id == "cell-1"
+        assert result.cells[1].input_type == "markdown"
+
+    def test_cell_with_selection(self):
+        raw = {
+            "value": "nb.ipynb",
+            "type": "notebook",
+            "cells": [
+                {
+                    "id": "c1",
+                    "input_type": "code",
+                    "selection": {"start": [1, 0], "end": [3, 5], "content": "x = 1"},
+                },
+            ],
+        }
+        result = _deserialize_attachment(raw)
+        cell = result.cells[0]
+        assert isinstance(cell.selection, AttachmentSelection)
+        assert cell.selection.start == (1, 0)
+        assert cell.selection.content == "x = 1"
+
+    def test_malformed_selection_becomes_none(self):
+        """Selection missing required fields is set to None."""
+        raw = {
+            "value": "x.py",
+            "type": "file",
+            "selection": {"start": [1, 0]},  # missing end and content
+        }
+        result = _deserialize_attachment(raw)
+        assert isinstance(result, FileAttachment)
+        assert result.selection is None
+
+    def test_missing_required_field_returns_none(self):
+        """Missing required 'value' field causes graceful None return."""
+        raw = {"type": "file"}  # missing 'value'
+        assert _deserialize_attachment(raw) is None

--- a/jupyter_ai_acp_client/tests/test_default_acp_client.py
+++ b/jupyter_ai_acp_client/tests/test_default_acp_client.py
@@ -4,8 +4,17 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 from acp.schema import ResourceContentBlock, TextContentBlock
+from jupyterlab_chat.models import (
+    AttachmentSelection,
+    FileAttachment,
+    NotebookAttachment,
+    NotebookAttachmentCell,
+)
 
-from jupyter_ai_acp_client.default_acp_client import JaiAcpClient
+from jupyter_ai_acp_client.default_acp_client import (
+    JaiAcpClient,
+    _build_attachment_description,
+)
 
 
 SESSION_ID = "sess-1"
@@ -54,13 +63,14 @@ class TestPromptAndReplyContentBlocks:
         assert blocks[0].text == "hello"
 
     async def test_file_attachment_produces_resource_block(self):
-        """A file attachment produces a ResourceContentBlock with file:// URI."""
+        """A FileAttachment produces a ResourceContentBlock with correct fields."""
         client, conn, _ = _make_client_and_persona()
 
+        att = FileAttachment(value="src/main.py", mimetype="text/x-python")
         await client.prompt_and_reply(
             session_id=SESSION_ID,
-            prompt="check this",
-            attachments=[{"value": "src/main.py", "type": "file", "mimetype": "text/x-python"}],
+            prompt="review",
+            attachments=[att],
             root_dir="/home/user/notebooks",
         )
 
@@ -72,50 +82,53 @@ class TestPromptAndReplyContentBlocks:
         assert blocks[1].mime_type == "text/x-python"
 
     async def test_notebook_attachment_default_mime_type(self):
-        """Notebook attachments get application/x-ipynb+json when mimetype is None."""
+        """NotebookAttachment gets default application/x-ipynb+json MIME type."""
         client, conn, _ = _make_client_and_persona()
 
+        att = NotebookAttachment(value="analysis.ipynb")
         await client.prompt_and_reply(
             session_id=SESSION_ID,
-            prompt="review",
-            attachments=[{"value": "analysis.ipynb", "type": "notebook"}],
-            root_dir="/home/user",
+            prompt="check",
+            attachments=[att],
+            root_dir="/tmp",
         )
 
         blocks = conn.prompt.call_args.kwargs["prompt"]
         assert blocks[1].mime_type == "application/x-ipynb+json"
 
-    async def test_notebook_explicit_mimetype_preserved(self):
-        """When notebook has explicit mimetype, it is preserved."""
+    async def test_file_explicit_mimetype_preserved(self):
+        """Explicit mimetype on FileAttachment is preserved."""
         client, conn, _ = _make_client_and_persona()
 
+        att = FileAttachment(value="data.csv", mimetype="text/csv")
         await client.prompt_and_reply(
             session_id=SESSION_ID,
-            prompt="review",
-            attachments=[{"value": "nb.ipynb", "type": "notebook", "mimetype": "custom/type"}],
-            root_dir="/home/user",
+            prompt="parse",
+            attachments=[att],
+            root_dir="/tmp",
         )
 
         blocks = conn.prompt.call_args.kwargs["prompt"]
-        assert blocks[1].mime_type == "custom/type"
+        assert blocks[1].mime_type == "text/csv"
 
     async def test_multiple_attachments_in_order(self):
-        """Multiple attachments produce ResourceContentBlocks in order after text."""
+        """Multiple attachments produce resource blocks in order after text."""
         client, conn, _ = _make_client_and_persona()
 
+        atts = [
+            FileAttachment(value="a.py"),
+            NotebookAttachment(value="b.ipynb"),
+        ]
         await client.prompt_and_reply(
             session_id=SESSION_ID,
-            prompt="review all",
-            attachments=[
-                {"value": "a.py", "type": "file"},
-                {"value": "b.ipynb", "type": "notebook"},
-            ],
+            prompt="review",
+            attachments=atts,
             root_dir="/tmp",
         )
 
         blocks = conn.prompt.call_args.kwargs["prompt"]
         assert len(blocks) == 3
-        assert blocks[0].text == "review all"
+        assert isinstance(blocks[0], TextContentBlock)
         assert blocks[1].name == "a.py"
         assert blocks[2].name == "b.ipynb"
         assert blocks[2].mime_type == "application/x-ipynb+json"
@@ -150,23 +163,25 @@ class TestPromptAndReplyContentBlocks:
         """When attachment value is empty, name falls back to '<attachment>'."""
         client, conn, _ = _make_client_and_persona()
 
+        att = FileAttachment(value="")
         await client.prompt_and_reply(
             session_id=SESSION_ID,
             prompt="check",
-            attachments=[{"value": "", "type": "file"}],
+            attachments=[att],
         )
 
         blocks = conn.prompt.call_args.kwargs["prompt"]
         assert blocks[1].name == "<attachment>"
 
     async def test_mimetype_none_for_file(self):
-        """File attachment with no mimetype gets None mime_type."""
+        """File without explicit mimetype gets None mime_type."""
         client, conn, _ = _make_client_and_persona()
 
+        att = FileAttachment(value="unknown.xyz")
         await client.prompt_and_reply(
             session_id=SESSION_ID,
             prompt="check",
-            attachments=[{"value": "data.csv", "type": "file"}],
+            attachments=[att],
             root_dir="/tmp",
         )
 
@@ -174,43 +189,191 @@ class TestPromptAndReplyContentBlocks:
         assert blocks[1].mime_type is None
 
     async def test_no_root_dir_uses_relative_path(self):
-        """When root_dir is None, URI is the raw relative path."""
+        """Without root_dir, attachment value is used as-is for URI."""
         client, conn, _ = _make_client_and_persona()
 
+        att = FileAttachment(value="src/main.py")
         await client.prompt_and_reply(
             session_id=SESSION_ID,
             prompt="check",
-            attachments=[{"value": "subdir/file.py", "type": "file"}],
-            root_dir=None,
+            attachments=[att],
         )
 
         blocks = conn.prompt.call_args.kwargs["prompt"]
-        assert blocks[1].uri == "subdir/file.py"
+        assert blocks[1].uri == "src/main.py"
 
     async def test_file_uri_format(self):
-        """file:// URI has correct RFC 8089 format with three slashes."""
+        """With root_dir, attachment gets a file:// URI."""
         client, conn, _ = _make_client_and_persona()
 
+        att = FileAttachment(value="main.py")
         await client.prompt_and_reply(
             session_id=SESSION_ID,
             prompt="check",
-            attachments=[{"value": "test.py", "type": "file"}],
-            root_dir="/home/user",
+            attachments=[att],
+            root_dir="/tmp",
         )
 
         blocks = conn.prompt.call_args.kwargs["prompt"]
-        assert blocks[1].uri.startswith("file:///")
+        assert blocks[1].uri == Path("/tmp/main.py").as_uri()
 
     async def test_path_traversal_blocked(self):
-        """Attachment path escaping root_dir falls back to raw relative path."""
+        """Path traversal attempt falls back to raw value."""
         client, conn, _ = _make_client_and_persona()
 
         await client.prompt_and_reply(
             session_id=SESSION_ID,
             prompt="check",
-            attachments=[{"value": "../../../etc/passwd", "type": "file"}],
+            attachments=[FileAttachment(value="../../../etc/passwd")],
             root_dir="/home/user/notebooks",
         )
 
         blocks = conn.prompt.call_args.kwargs["prompt"]
         assert blocks[1].uri == "../../../etc/passwd"
+
+    async def test_file_selection_produces_description(self):
+        """File with selection gets human-readable line range in description."""
+        client, conn, _ = _make_client_and_persona()
+
+        att = FileAttachment(
+            value="main.py",
+            selection=AttachmentSelection(start=(5, 0), end=(10, 0), content="..."),
+        )
+        await client.prompt_and_reply(
+            session_id=SESSION_ID,
+            prompt="check",
+            attachments=[att],
+            root_dir="/tmp",
+        )
+
+        blocks = conn.prompt.call_args.kwargs["prompt"]
+        assert blocks[1].description == "Lines 6-11"
+
+    async def test_notebook_cells_produce_description(self):
+        """Notebook with cells gets cell IDs in description."""
+        client, conn, _ = _make_client_and_persona()
+
+        att = NotebookAttachment(
+            value="nb.ipynb",
+            cells=[
+                NotebookAttachmentCell(id="abc", input_type="code"),
+                NotebookAttachmentCell(id="def", input_type="markdown"),
+            ],
+        )
+        await client.prompt_and_reply(
+            session_id=SESSION_ID,
+            prompt="check",
+            attachments=[att],
+            root_dir="/tmp",
+        )
+
+        blocks = conn.prompt.call_args.kwargs["prompt"]
+        assert blocks[1].description == 'Selected cells: Cell "abc", Cell "def"'
+
+    async def test_no_selection_no_description(self):
+        """File without selection gets None description."""
+        client, conn, _ = _make_client_and_persona()
+
+        await client.prompt_and_reply(
+            session_id=SESSION_ID,
+            prompt="check",
+            attachments=[FileAttachment(value="plain.py")],
+            root_dir="/tmp",
+        )
+
+        blocks = conn.prompt.call_args.kwargs["prompt"]
+        assert blocks[1].description is None
+
+
+class TestAttachmentDescription:
+    """Tests for _build_attachment_description helper."""
+
+    def test_file_no_selection(self):
+        att = FileAttachment(value="main.py")
+        assert _build_attachment_description(att) is None
+
+    def test_file_single_line_selection(self):
+        att = FileAttachment(
+            value="main.py",
+            selection=AttachmentSelection(start=(6, 0), end=(6, 15), content="x = 1"),
+        )
+        assert _build_attachment_description(att) == "Line 7"
+
+    def test_file_multi_line_selection(self):
+        att = FileAttachment(
+            value="main.py",
+            selection=AttachmentSelection(start=(5, 0), end=(10, 0), content="..."),
+        )
+        assert _build_attachment_description(att) == "Lines 6-11"
+
+    def test_notebook_no_cells(self):
+        att = NotebookAttachment(value="nb.ipynb")
+        assert _build_attachment_description(att) is None
+
+    def test_notebook_cells_without_selection(self):
+        att = NotebookAttachment(
+            value="nb.ipynb",
+            cells=[
+                NotebookAttachmentCell(id="abc", input_type="code"),
+                NotebookAttachmentCell(id="def", input_type="markdown"),
+            ],
+        )
+        assert _build_attachment_description(att) == 'Selected cells: Cell "abc", Cell "def"'
+
+    def test_notebook_cell_with_single_line_selection(self):
+        att = NotebookAttachment(
+            value="nb.ipynb",
+            cells=[
+                NotebookAttachmentCell(
+                    id="abc",
+                    input_type="code",
+                    selection=AttachmentSelection(start=(4, 0), end=(4, 10), content="x"),
+                ),
+            ],
+        )
+        assert _build_attachment_description(att) == 'Selected cells: Cell "abc" (line 5)'
+
+    def test_notebook_cell_with_multi_line_selection(self):
+        att = NotebookAttachment(
+            value="nb.ipynb",
+            cells=[
+                NotebookAttachmentCell(
+                    id="abc",
+                    input_type="code",
+                    selection=AttachmentSelection(start=(0, 0), end=(2, 5), content="..."),
+                ),
+            ],
+        )
+        assert _build_attachment_description(att) == 'Selected cells: Cell "abc" (lines 1-3)'
+
+    def test_notebook_mixed_cells(self):
+        """Some cells with selection, some without."""
+        att = NotebookAttachment(
+            value="nb.ipynb",
+            cells=[
+                NotebookAttachmentCell(
+                    id="abc",
+                    input_type="code",
+                    selection=AttachmentSelection(start=(0, 0), end=(2, 0), content="..."),
+                ),
+                NotebookAttachmentCell(id="def", input_type="markdown"),
+                NotebookAttachmentCell(
+                    id="ghi",
+                    input_type="code",
+                    selection=AttachmentSelection(start=(4, 0), end=(7, 0), content="..."),
+                ),
+            ],
+        )
+        assert _build_attachment_description(att) == 'Selected cells: Cell "abc" (lines 1-3), Cell "def", Cell "ghi" (lines 5-8)'
+
+    def test_notebook_empty_cells_list(self):
+        att = NotebookAttachment(value="nb.ipynb", cells=[])
+        assert _build_attachment_description(att) is None
+
+    def test_zero_indexed_to_one_indexed(self):
+        """Verifies 0-indexed CodeMirror positions become 1-indexed."""
+        att = FileAttachment(
+            value="main.py",
+            selection=AttachmentSelection(start=(0, 0), end=(0, 5), content="x"),
+        )
+        assert _build_attachment_description(att) == "Line 1"


### PR DESCRIPTION
Addresses #37 and #38 (unified per review feedback).

Deserializes YChat attachments from raw dicts to typed FileAttachment / NotebookAttachment dataclasses, builds file:// URIs with a path traversal guard, and forwards selection/cell metadata to ACP agents via ResourceContentBlock.description.

Changes:
- _deserialize_attachment() + _reconstruct_selection() in base_acp_persona.py
- _build_attachment_description() in default_acp_client.py
- prompt_and_reply() updated to accept typed attachments with description=
- 44 new tests (19 + 25)

pycrdt 0.12.48 fixes the tuple bug upstream (y-crdt/pycrdt#370), so the deserialization is straightforward.