### PR TITLE
Bump Gemini ACP version

### DIFF
--- a/jupyter_ai_acp_client/acp_personas/gemini.py
+++ b/jupyter_ai_acp_client/acp_personas/gemini.py
@@ -47,8 +47,8 @@ try:
     version_str = version_match.group(1)
     version_parts = [int(x) for x in version_str.split('.')]
 
-    # Check if version >= 0.1.13
-    required_version = (0, 1, 13)
+    # Check if version >= 0.34.0
+    required_version = (0, 34, 0)
     current_version = tuple(version_parts)
 
     if current_version < required_version:


### PR DESCRIPTION
Fixes #60 

Updated Gemini ACP version to 0.34.0 (minimum required)
This version no longer needs the `--experimental-acp` flag and it has been replaced with the `--acp` flag. 

<img width="604" height="295" alt="image" src="https://github.com/user-attachments/assets/7dcd0f26-2424-4f39-8364-df120108043e" />

