### PR TITLE
Downgrade excessive info logs to debug

### DIFF
--- a/jupyter_ai_acp_client/acp_personas/claude.py
+++ b/jupyter_ai_acp_client/acp_personas/claude.py
@@ -53,7 +53,7 @@ class ClaudeAcpPersona(BaseAcpPersona):
             await super().process_message(message)
         except RequestError as e:
             if "Authentication required" in str(e):
-                self.log.info("[Claude] User is not logged in.")
+                self.log.debug("[Claude] User is not logged in.")
                 await self.handle_no_auth(message)
             else:
                 raise e

--- a/jupyter_ai_acp_client/acp_personas/gemini.py
+++ b/jupyter_ai_acp_client/acp_personas/gemini.py
@@ -101,14 +101,14 @@ class GeminiAcpPersona(BaseAcpPersona):
 
             # Reaching here := user is not signed in
             if not failed_auth_check:
-                self.log.info("[Gemini] User is not signed in.")
+                self.log.debug("[Gemini] User is not signed in.")
                 failed_auth_check = True
 
             # Re-check every 2 seconds
             await asyncio.sleep(2)
 
         # Reaching this point := user is authenticated
-        self.log.info("[Gemini] User is signed in.")
+        self.log.debug("[Gemini] User is signed in.")
 
         # If initially signed out, send a message letting the user know they are
         # now signed in.

--- a/jupyter_ai_acp_client/acp_personas/kiro.py
+++ b/jupyter_ai_acp_client/acp_personas/kiro.py
@@ -102,14 +102,14 @@ class KiroAcpPersona(BaseAcpPersona):
 
             # Reaching here := user is not signed in
             if not failed_auth_check:
-                self.log.info("[Kiro] User is not signed in.")
+                self.log.debug("[Kiro] User is not signed in.")
                 failed_auth_check = True
 
             # Re-check every 2 seconds
             await asyncio.sleep(2)
         
         # Reaching this point := user is authenticated
-        self.log.info("[Kiro] User is signed in.")
+        self.log.debug("[Kiro] User is signed in.")
 
         # If initially signed out, send a message letting the user know they are
         # now signed in.

--- a/jupyter_ai_acp_client/acp_personas/mistral_vibe.py
+++ b/jupyter_ai_acp_client/acp_personas/mistral_vibe.py
@@ -66,7 +66,7 @@ class MistralVibeAcpPersona(BaseAcpPersona):
             if not _is_auth_error(error):
                 raise
 
-            self.log.info(
+            self.log.debug(
                 "[Mistral Vibe] Authentication or configuration required: %s",
                 error,
             )

--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -101,13 +101,13 @@ class BaseAcpPersona(BasePersona):
             stderr=sys.stderr,
             limit=50 * 1024 * 1024,
         )
-        self.log.info("Spawned ACP agent subprocess for '%s'.", self.__class__.__name__)
+        self.log.debug("Spawned ACP agent subprocess for '%s'.", self.__class__.__name__)
         return process
 
     async def _init_client(self) -> JaiAcpClient:
         agent_subprocess = await self.get_agent_subprocess()
         client = JaiAcpClient(agent_subprocess=agent_subprocess, event_loop=self.event_loop)
-        self.log.info("Initialized ACP client for '%s'.", self.__class__.__name__)
+        self.log.debug("Initialized ACP client for '%s'.", self.__class__.__name__)
         return client
     
     def _get_existing_sessions(self) -> dict[str, str]:
@@ -145,7 +145,7 @@ class BaseAcpPersona(BasePersona):
             # load existing session if one exists and the agent indicates it
             # supports loading sessions in its agent capabilities
             response = await client.load_session(persona=self, session_id=existing_session_id)
-            self.log.info(
+            self.log.debug(
                 "Loaded existing ACP client session for '%s' with ID '%s'.",
                 self.__class__.__name__,
                 existing_session_id,
@@ -154,7 +154,7 @@ class BaseAcpPersona(BasePersona):
         else:
             # otherwise create new session and add it to the metadata
             response = await client.create_session(persona=self)
-            self.log.info(
+            self.log.debug(
                 "Initialized new ACP client session for '%s' with ID '%s'.",
                 self.__class__.__name__,
                 response.session_id,
@@ -258,7 +258,7 @@ class BaseAcpPersona(BasePersona):
     
     @acp_slash_commands.setter
     def acp_slash_commands(self, commands: list[AvailableCommand]):
-        self.log.info(
+        self.log.debug(
             "Setting %d slash commands for '%s' in room '%s'.",
             len(commands),
             self.name,
@@ -274,7 +274,7 @@ class BaseAcpPersona(BasePersona):
         self.event_loop.create_task(self._shutdown())
 
     async def _shutdown(self):
-        self.log.info("Closing ACP agent and client for '%s'.", self.__class__.__name__)
+        self.log.debug("Closing ACP agent and client for '%s'.", self.__class__.__name__)
         client = await self.get_client()
         try:
             session_id = await self.get_session_id()
@@ -305,4 +305,4 @@ class BaseAcpPersona(BasePersona):
                 self.__class__.__name__,
                 exc_info=True,
             )
-        self.log.info("Successfully closed ACP agent and client for '%s'.", self.__class__.__name__)
+        self.log.debug("Successfully closed ACP agent and client for '%s'.", self.__class__.__name__)

--- a/jupyter_ai_acp_client/default_acp_client.py
+++ b/jupyter_ai_acp_client/default_acp_client.py
@@ -253,7 +253,7 @@ class JaiAcpClient(Client):
             # Reset session state for this prompt
             self._tool_call_manager.reset(session_id)
 
-            persona.log.info(f"prompt_and_reply: starting for session {session_id}")
+            persona.log.debug(f"prompt_and_reply: starting for session {session_id}")
 
             # Set awareness to indicate writing
             persona.awareness.set_local_state_field("isWriting", True)
@@ -317,7 +317,7 @@ class JaiAcpClient(Client):
                             trigger_actions=[find_mentions],
                         )
 
-                persona.log.info(f"prompt_and_reply: completed for session {session_id}")
+                persona.log.debug(f"prompt_and_reply: completed for session {session_id}")
                 return response
             except Exception:
                 persona.log.exception(f"prompt_and_reply: failed for session {session_id}")
@@ -347,7 +347,7 @@ class JaiAcpClient(Client):
         if persona is None:
             return
         message_id = self._tool_call_manager.get_or_create_text_message(session_id, persona)
-        persona.log.info(f"agent_message_chunk: {len(text)} chars")
+        persona.log.debug(f"agent_message_chunk: {len(text)} chars")
 
         msg = Message(
             id=message_id,
@@ -382,7 +382,7 @@ class JaiAcpClient(Client):
 
         persona = self._personas_by_session.get(session_id)
         if persona:
-            persona.log.info(f"session_update: {type(update).__name__} for session {session_id}")
+            persona.log.debug(f"session_update: {type(update).__name__} for session {session_id}")
 
         if isinstance(update, AvailableCommandsUpdate):
             if not update.available_commands:
@@ -440,7 +440,7 @@ class JaiAcpClient(Client):
             )
 
         try:
-            persona.log.info(
+            persona.log.debug(
                 f"request_permission: CALLED session={session_id} "
                 f"tool_call_id={tool_call.tool_call_id} "
                 f"options_count={len(options)} "
@@ -454,7 +454,7 @@ class JaiAcpClient(Client):
                 session_id, tool_call.tool_call_id, options=permission_options
             )
 
-            persona.log.info(
+            persona.log.debug(
                 f"request_permission: {len(permission_options)} permission_options"
             )
 
@@ -698,7 +698,7 @@ class JaiAcpClient(Client):
         # Cancel pending permissions
         rejected = self._permission_manager.cancel_all_pending(session_id)
         if rejected and persona:
-            persona.log.info(
+            persona.log.debug(
                 f"_cancel_pending_work: auto-rejected {rejected} pending permission(s) for session {session_id}"
             )
 

--- a/jupyter_ai_acp_client/tool_call_manager.py
+++ b/jupyter_ai_acp_client/tool_call_manager.py
@@ -89,7 +89,7 @@ class ToolCallManager:
         )
         session.current_message_id = message_id
         session.all_message_ids.append(message_id)
-        persona.log.info(f"Created message {message_id} for session {session_id}")
+        persona.log.debug(f"Created message {message_id} for session {session_id}")
         persona.awareness.set_local_state_field("isWriting", message_id)
 
         return message_id
@@ -208,7 +208,7 @@ class ToolCallManager:
 
         raw_input = ensure_serializable(update.raw_input)
 
-        persona.log.info(
+        persona.log.debug(
             f"tool_call_start: id={update.tool_call_id} title={update.title!r}"
             f" kind={kind_str} locations={locations_paths}"
             f" diffs={len(diffs) if diffs else 0}"
@@ -246,7 +246,7 @@ class ToolCallManager:
             [loc.path for loc in update.locations] if update.locations else None
         )
         diffs = extract_diffs(update.content, root_dir=persona.parent.root_dir)
-        persona.log.info(
+        persona.log.debug(
             f"tool_call_progress: id={update.tool_call_id} title={update.title!r}"
             f" status={status_str} locations={locations_paths}"
             f" diffs={len(diffs) if diffs else 0}"


### PR DESCRIPTION
## Summary

Closes #18.

- Downgraded all `log.info()` calls to `log.debug()` across 7 files (23 occurrences total)
- Affected modules: `base_acp_persona.py`, `default_acp_client.py`, `tool_call_manager.py`, and all 4 persona files (`claude.py`, `kiro.py`, `gemini.py`, `mistral_vibe.py`)
- These were routine lifecycle messages (subprocess spawned, session created, message chunks received, tool call events, permission requests, etc.) that clutter server output at default log levels
- All messages remain available via `--debug` flag for troubleshooting

## Test plan

- [ ] Start JupyterLab with default log level — verify no ACP lifecycle spam in server output
- [ ] Start JupyterLab with `--debug` — verify all messages still appear
- [ ] Run `pytest -vv -r ap --cov jupyter_ai_acp_client` — verify existing tests pass