### PR TITLE
fix: respawn ACP subprocess when it dies

### DIFF
--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -196,8 +196,30 @@ class BaseAcpPersona(BasePersona):
     async def get_agent_subprocess(self) -> asyncio.subprocess.Process:
         """
         Safely returns the ACP agent subprocess for this persona.
+
+        If the subprocess has exited (e.g. crash, OOM, external kill),
+        automatically respawns it along with a new client and connection.
+        Without this, a dead subprocess leaves the persona permanently
+        unresponsive until the entire JupyterLab server is restarted.
         """
-        return await self.__class__._subprocess_future
+        process = await self.__class__._subprocess_future
+        if process.returncode is not None:
+            self.log.warning(
+                "ACP agent subprocess for '%s' exited with code %s. Respawning.",
+                self.__class__.__name__,
+                process.returncode,
+            )
+            self.__class__._before_subprocess_future = self.event_loop.create_task(
+                self.before_agent_subprocess()
+            )
+            self.__class__._subprocess_future = self.event_loop.create_task(
+                self._init_agent_subprocess()
+            )
+            self.__class__._client_future = self.event_loop.create_task(
+                self._init_client()
+            )
+            process = await self.__class__._subprocess_future
+        return process
 
     async def get_client(self) -> JaiAcpClient:
         """
@@ -251,8 +273,24 @@ class BaseAcpPersona(BasePersona):
             await self.handle_no_auth(message)
             return
 
-        client = await self.get_client()
-        session_id = await self.get_session_id()
+        # Ensure subprocess is alive (respawns if dead via get_agent_subprocess)
+        await self.get_agent_subprocess()
+
+        try:
+            client = await self.get_client()
+            session_id = await self.get_session_id()
+        except Exception:
+            # After a subprocess respawn, the old client/session are invalid.
+            # Re-initialize the session against the new client.
+            self.log.warning(
+                "Client or session invalid for '%s', re-initializing after respawn.",
+                self.__class__.__name__,
+            )
+            self._client_session_future = self.event_loop.create_task(
+                self._init_client_session()
+            )
+            client = await self.get_client()
+            session_id = await self.get_session_id()
 
         prompt = message.body.replace("@" + self.as_user().mention_name, "").strip()
 


### PR DESCRIPTION
## Summary

When the ACP agent subprocess exits (crash, OOM, external `kill`), the persona becomes permanently unresponsive. All subsequent `@OpenCode` messages silently fail. The only recovery is restarting the JupyterLab server.

## Root cause

`_subprocess_future` is a `ClassVar` that caches the subprocess `Task`. The `__init__` guard only creates a new task if the future is `None`:

```python
if "_subprocess_future" not in self.__class__.__dict__ or self.__class__._subprocess_future is None:
    self.__class__._subprocess_future = ...
```

When the subprocess dies, the future still holds the completed task with the dead `Process` object — it's not `None`. No new persona instance triggers a respawn. The `_shutdown()` method resets the class vars to `None`, but an external kill doesn't trigger shutdown.

## Fix

**`get_agent_subprocess()`** — after awaiting the subprocess, check `process.returncode`. If non-`None` (process exited), reset the class-level futures and respawn:

```python
process = await self.__class__._subprocess_future
if process.returncode is not None:
    # Respawn subprocess, client, and connection
    self.__class__._subprocess_future = self.event_loop.create_task(self._init_agent_subprocess())
    self.__class__._client_future = self.event_loop.create_task(self._init_client())
    process = await self.__class__._subprocess_future
return process
```

**`process_message()`** — after a respawn, the per-instance `_client_session_future` is stale (points at the old client). Wrap the client/session calls in try/except and re-initialize the session on failure.

## How we found this

In production, we ran `kubectl exec jupyter-chris -- kill <pid>` to unstick a process blocked on an `external_directory` permission prompt. The ACP process died, jupyter-ai didn't respawn it, and all subsequent chat messages went nowhere. Browser refresh didn't help because the stale `ClassVar` lives in the server process.

## Test plan

- [ ] Kill `opencode acp` process while JupyterLab is running
- [ ] Send a new `@OpenCode` message
- [ ] Verify the subprocess respawns and the chat responds