### PR TITLE
Added lazy init for acp clients

### DIFF
--- a/jupyter_ai_acp_client/acp_personas/gemini.py
+++ b/jupyter_ai_acp_client/acp_personas/gemini.py
@@ -117,10 +117,6 @@ class GeminiAcpPersona(BaseAcpPersona):
             self.send_message("Thanks for signing in! I'm ready to help.")
 
     async def is_authed(self) -> bool:
-        if self._before_subprocess_future is None:
-            return False
-        if not self._before_subprocess_future.done():
-            return False
         return await self._check_gemini_auth_fast()
 
     async def handle_no_auth(self, message: Message) -> None:

--- a/jupyter_ai_acp_client/acp_personas/gemini.py
+++ b/jupyter_ai_acp_client/acp_personas/gemini.py
@@ -117,6 +117,26 @@ class GeminiAcpPersona(BaseAcpPersona):
             self.send_message("Thanks for signing in! I'm ready to help.")
 
     async def is_authed(self) -> bool:
+        if not await self._check_gemini_auth_fast():
+            return False
+
+        self._start_auth_check()
+        future = self.__class__._before_subprocess_future
+
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(future),
+                timeout=5.0,
+            )
+        except asyncio.TimeoutError:
+            return False
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.log.warning("[Gemini] Auth check failed.", exc_info=True)
+            self.__class__._before_subprocess_future = None
+            return False
+
         return await self._check_gemini_auth_fast()
 
     async def handle_no_auth(self, message: Message) -> None:

--- a/jupyter_ai_acp_client/acp_personas/gemini.py
+++ b/jupyter_ai_acp_client/acp_personas/gemini.py
@@ -117,13 +117,10 @@ class GeminiAcpPersona(BaseAcpPersona):
             self.send_message("Thanks for signing in! I'm ready to help.")
 
     async def is_authed(self) -> bool:
-        # Check if the before_subprocess task is done (subprocess has started)
+        if self._before_subprocess_future is None:
+            return False
         if not self._before_subprocess_future.done():
             return False
-
-        # In Gemini, configuration can change at runtime (e.g., if settings.json
-        # is deleted), so we need to verify that Gemini is still properly
-        # configured before processing each message. Use a fast file check.
         return await self._check_gemini_auth_fast()
 
     async def handle_no_auth(self, message: Message) -> None:

--- a/jupyter_ai_acp_client/acp_personas/kiro.py
+++ b/jupyter_ai_acp_client/acp_personas/kiro.py
@@ -120,18 +120,25 @@ class KiroAcpPersona(BaseAcpPersona):
     async def is_authed(self) -> bool:
         # Start auth polling if not already started (idempotent).
         self._start_auth_check()
-        if self.__class__._before_subprocess_future.done():
-            return True
+        future = self.__class__._before_subprocess_future
+
         # Future not yet resolved — wait up to one polling cycle.
-        # kiro-cli whoami is fast when authenticated, so this resolves quickly.
+        # _start_auth_check() is fast when authenticated.
         try:
             await asyncio.wait_for(
-                asyncio.shield(self.__class__._before_subprocess_future),
+                asyncio.shield(future),
                 timeout=2.0,
             )
-            return True
-        except (asyncio.TimeoutError, asyncio.CancelledError):
+        except asyncio.TimeoutError:
             return False
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.log.warning("[Kiro] Auth check failed.", exc_info=True)
+            self.__class__._before_subprocess_future = None
+            return False
+
+        return True
     
     async def handle_no_auth(self, message: Message) -> None:
         # Determine which command to show

--- a/jupyter_ai_acp_client/acp_personas/kiro.py
+++ b/jupyter_ai_acp_client/acp_personas/kiro.py
@@ -118,9 +118,20 @@ class KiroAcpPersona(BaseAcpPersona):
             self.send_message("Thanks for signing in! I'm ready to help.")
     
     async def is_authed(self) -> bool:
-        if self._before_subprocess_future is None:
+        # Start auth polling if not already started (idempotent).
+        self._start_auth_check()
+        if self.__class__._before_subprocess_future.done():
+            return True
+        # Future not yet resolved — wait up to one polling cycle.
+        # kiro-cli whoami is fast when authenticated, so this resolves quickly.
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(self.__class__._before_subprocess_future),
+                timeout=2.0,
+            )
+            return True
+        except (asyncio.TimeoutError, asyncio.CancelledError):
             return False
-        return self._before_subprocess_future.done()
     
     async def handle_no_auth(self, message: Message) -> None:
         # Determine which command to show

--- a/jupyter_ai_acp_client/acp_personas/kiro.py
+++ b/jupyter_ai_acp_client/acp_personas/kiro.py
@@ -52,7 +52,7 @@ try:
     required_version = (1, 25, 0)
     current_version = tuple(version_parts)
 
-    if current_version < required_version or current_version[0] >= 2:
+    if current_version < required_version or current_version[0] >= 3:
         raise PersonaRequirementsUnmet(
             f"kiro-cli version {version_str} is installed, but version >=1.25.0,<2 is required."
             " Please upgrade kiro-cli. See https://kiro.dev for instructions."
@@ -118,10 +118,8 @@ class KiroAcpPersona(BaseAcpPersona):
             self.send_message("Thanks for signing in! I'm ready to help.")
     
     async def is_authed(self) -> bool:
-        # In Kiro, the user remains signed in even if they sign out while the
-        # ACP agent server is running. Therefore we can just return the status
-        # of the `before_agent_subprocess()` task to check if the user is
-        # authenticated.
+        if self._before_subprocess_future is None:
+            return False
         return self._before_subprocess_future.done()
     
     async def handle_no_auth(self, message: Message) -> None:

--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -322,45 +322,56 @@ class BaseAcpPersona(BasePersona):
             await self.handle_no_auth(message)
             return
 
-        # Block until fully initialized
-        await self.ensure_initialized()
+        # Show writing indicator immediately, before init may block.
+        # NOTE: This reuses the "isWriting" awareness state to show "{agent} is
+        # typing..." during initialization. Ideally, the UI would show a
+        # distinct status (e.g. "starting up..."), but that requires a richer
+        # awareness protocol and changes in jupyter-chat.
+        self.awareness.set_local_state_field("isWriting", True)
 
-        client = await self.get_client()
-        session_id = await self.get_session_id()
+        try:
+            # Block until fully initialized
+            await self.ensure_initialized()
 
-        prompt = message.body.replace("@" + self.as_user().mention_name, "").strip()
+            client = await self.get_client()
+            session_id = await self.get_session_id()
 
-        if self._pending_session_recovery_context:
-            self._pending_session_recovery_context = False
-            history = self._build_history_context(exclude_id=message.id)
-            if history:
-                emit_event(
-                    self.event_logger,
-                    "acp_session_recovery",
-                    "success",
-                    {"persona_class": self.__class__.__name__},
-                )
-                prompt = history + "\n\nCurrent user message:\n" + prompt
+            prompt = message.body.replace("@" + self.as_user().mention_name, "").strip()
 
-        # Resolve attachments from YChat by ID
-        attachments: list[dict] | None = None
-        if message.attachments:
-            all_attachments = self.ychat.get_attachments()
-            resolved = []
-            for aid in message.attachments:
-                raw = all_attachments.get(aid)
-                if raw is None:
-                    self.log.warning("Attachment %s not found in YChat", aid)
-                    continue
-                resolved.append(raw)
-            attachments = resolved or None
+            if self._pending_session_recovery_context:
+                self._pending_session_recovery_context = False
+                history = self._build_history_context(exclude_id=message.id)
+                if history:
+                    emit_event(
+                        self.event_logger,
+                        "acp_session_recovery",
+                        "success",
+                        {"persona_class": self.__class__.__name__},
+                    )
+                    prompt = history + "\n\nCurrent user message:\n" + prompt
 
-        await client.prompt_and_reply(
-            session_id=session_id,
-            prompt=prompt,
-            attachments=attachments,
-            root_dir=self.parent.root_dir,
-        )
+            # Resolve attachments from YChat by ID
+            attachments: list[dict] | None = None
+            if message.attachments:
+                all_attachments = self.ychat.get_attachments()
+                resolved = []
+                for aid in message.attachments:
+                    raw = all_attachments.get(aid)
+                    if raw is None:
+                        self.log.warning("Attachment %s not found in YChat", aid)
+                        continue
+                    resolved.append(raw)
+                attachments = resolved or None
+
+            await client.prompt_and_reply(
+                session_id=session_id,
+                prompt=prompt,
+                attachments=attachments,
+                root_dir=self.parent.root_dir,
+            )
+        except Exception:
+            self.awareness.set_local_state_field("isWriting", False)
+            raise
 
     @property
     def acp_slash_commands(self) -> list[AvailableCommand]:

--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -42,10 +42,11 @@ class BaseAcpPersona(BasePersona):
     Developers should always use `self.get_client()`.
     """
 
-    _client_session_future: Task[NewSessionResponse | LoadSessionResponse]
+    _client_session_future: Task[NewSessionResponse | LoadSessionResponse] | None
     """
     The future that yields the ACP client session info. Each instance of an ACP
     persona has a unique session ID, i.e. each chat reserves a unique session.
+    Set to `None` until initialization is triggered (lazy init).
 
     Developers should always call `self.get_session_response()` or `self.get_session_id()`.
     """
@@ -63,14 +64,33 @@ class BaseAcpPersona(BasePersona):
     context window limits.
     """
 
+    _initialized: bool
+    """Whether this persona instance has completed full initialization."""
+
     def __init__(self, *args, executable: list[str], **kwargs):
         super().__init__(*args, **kwargs)
 
         self._executable = executable
         self._pending_session_recovery_context: bool = False
+        self._client_session_future = None
+        self._initialized = False
+        self._acp_slash_commands = []
 
-        # Ensure each subclass has its own subprocess and client by checking if the
-        # class variable is defined directly on this class (not inherited)
+        # Eagerly initialize if this is the default persona or has an existing
+        # session from a previous chat open.
+        should_eager_init = (
+            self.parent.default_persona_id == self.id
+            or self.id in self._get_existing_sessions()
+        )
+        if should_eager_init:
+            self.event_loop.create_task(self.ensure_initialized())
+
+    def _start_auth_check(self) -> None:
+        """
+        Non-blocking: starts only the before_agent_subprocess future so that
+        auth-gated personas (Kiro, Gemini) begin polling. Does not start the
+        agent subprocess, client, or session.
+        """
         if (
             "_before_subprocess_future" not in self.__class__.__dict__
             or self.__class__._before_subprocess_future is None
@@ -78,6 +98,15 @@ class BaseAcpPersona(BasePersona):
             self.__class__._before_subprocess_future = self.event_loop.create_task(
                 self.before_agent_subprocess()
             )
+
+    async def ensure_initialized(self) -> None:
+        """
+        Idempotent method that starts the subprocess → client → session chain
+        and awaits completion. Safe to call multiple times.
+        """
+        if self._initialized:
+            return
+        self._start_auth_check()
         if (
             "_subprocess_future" not in self.__class__.__dict__
             or self.__class__._subprocess_future is None
@@ -92,11 +121,12 @@ class BaseAcpPersona(BasePersona):
             self.__class__._client_future = self.event_loop.create_task(
                 self._init_client()
             )
-
-        self._client_session_future = self.event_loop.create_task(
-            self._init_client_session()
-        )
-        self._acp_slash_commands = []
+        if self._client_session_future is None:
+            self._client_session_future = self.event_loop.create_task(
+                self._init_client_session()
+            )
+        await self._client_session_future
+        self._initialized = True
 
     async def before_agent_subprocess(self) -> None:
         """
@@ -284,10 +314,16 @@ class BaseAcpPersona(BasePersona):
 
         This method may be overriden by child classes.
         """
+        # Kick off auth check (non-blocking) so auth polling starts
+        self._start_auth_check()
+
         # If not authenticated, return early
         if not await self.is_authed():
             await self.handle_no_auth(message)
             return
+
+        # Block until fully initialized
+        await self.ensure_initialized()
 
         client = await self.get_client()
         session_id = await self.get_session_id()
@@ -357,6 +393,14 @@ class BaseAcpPersona(BasePersona):
 
     async def _shutdown(self):
         self.log.info("[shutdown] Starting for '%s'.", self.__class__.__name__)
+
+        # Skip shutdown if this persona was never initialized
+        if self._client_session_future is None:
+            self.log.info(
+                "[shutdown] Persona '%s' was never initialized, skipping.",
+                self.__class__.__name__,
+            )
+            return
 
         # Cancel any pending startup futures to avoid hanging on auth-gated
         # personas (e.g. Kiro, Gemini) that never finished startup.

--- a/jupyter_ai_acp_client/tests/test_base_acp_persona.py
+++ b/jupyter_ai_acp_client/tests/test_base_acp_persona.py
@@ -20,6 +20,8 @@ def _make_persona(attachments_map: dict | None = None):
     persona.get_client = AsyncMock()
     persona.get_session_id = AsyncMock(return_value="sess-1")
     persona.is_authed = AsyncMock(return_value=True)
+    persona.ensure_initialized = AsyncMock()
+    persona._start_auth_check = MagicMock()
     persona._pending_session_recovery_context = False
 
     # as_user() is sync — must return a regular MagicMock


### PR DESCRIPTION
## Motivation

The current ACP persona implementation creates ACP agent subprocesses on server startup for all agents installed on the user's machine. In addition, when a chat is opened or created, new (or existing) sessions are  created for all agents, even before a single message is sent in the chat. This means that for each chat, the system will create new sessions for agents, whether the user ever calls upon that agent in the chat. While this is not inherently wrong, it does cause issues with the way some agents create and persist chat sessions, with some not persisting sessions if there are no message transactions. Due to this, we end up with a `init -> load_session -> failure -> create_session` loop every time a chat is initiated. Though, we tried to handle this with a fallback in #94, the root cause is not solved.

## Solution
This PR tackles this problem by lazily initializing everything from the agent subprocess to the session, when the user first sends the message in the chat, and only that particular agent is initialized. I have noticed no `load_session` errors that were still apparent with #94, along with a bit faster startup time for the chat, because no agents are initialized on start.

A few things that I noticed with this change:
-  We don't have a good way to communicate the current state of the agents (during initialization etc.), and so on first init, there could be a slight delay in when the user sends the message, and they see the "Clade Writing" status under the input box. 
- Another minor issue is that if a user is not logged in, the login will be initiated after they send the first message, and so they will need to repeat their message before the login. This only happens during their very first session.