### PR TITLE
Improved Gemini persona latency

### DIFF
--- a/jupyter_ai_acp_client/acp_personas/gemini.py
+++ b/jupyter_ai_acp_client/acp_personas/gemini.py
@@ -150,39 +150,13 @@ class GeminiAcpPersona(BaseAcpPersona):
 
     async def _check_gemini_auth(self) -> bool:
         """
-        Thorough authentication check that tests if Gemini CLI is properly configured.
+        Authentication check that verifies Gemini CLI is properly configured.
         Used during startup polling to wait for initial configuration.
+
+        Uses the fast file-based check only, avoiding `gemini --prompt` which
+        triggers a full LLM inference call and delays subprocess startup.
         """
-        # First check files exist
-        if not await self._check_gemini_auth_fast():
-            return False
-
-        try:
-            process = await asyncio.create_subprocess_exec(
-                "gemini", "--prompt", "test",
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE
-            )
-            _, stderr = await asyncio.wait_for(process.communicate(), timeout=5.0)
-
-            # Check if the command succeeded and didn't return auth/config errors
-            if process.returncode == 0:
-                return True
-
-            # Check stderr for configuration/auth errors
-            stderr_text = stderr.decode('utf-8', errors='ignore').lower()
-            if any(err in stderr_text for err in ['api key', 'not configured', 'authentication', 'sign in', 'login']):
-                return False
-
-            # If it failed for another reason, assume it's configured
-            return True
-
-        except asyncio.TimeoutError:
-            # If it times out, assume auth is working (command is just slow)
-            return True
-        except Exception:
-            # If command fails to run, assume not configured
-            return False
+        return await self._check_gemini_auth_fast()
 
     async def _open_gemini_login_terminal(self) -> bool:
         """


### PR DESCRIPTION
Problem: The Gemini persona using the ACP client to implement `gemini-cli` in Jupyter chat was responding very slowly. Running the Gemini CLI directly from the command line, there does not seem to be a problem but in the Jupyter  AI chat panel, it takes a long time to respond. For example, see the video below where it takes 12 seconds to the first response. 

https://github.com/user-attachments/assets/1e3d81c2-de93-4976-b1e5-bbd23f6158f1

The `_check_gemini_auth()` method was running `gemini --prompt "test"` — a full LLM  inference call — as its auth check. This was called in the `before_agent_subprocess()` polling loop, which blocks the ACP subprocess from even starting. So on every startup, the Gemini persona waited for a complete API round-trip (potentially several seconds) before the subprocess could launch.  If you compare with how other personas handle this:                                               
- Kiro uses kiro-cli whoami — a lightweight, instant auth check
- Claude and OpenCode don't gate startup at all — they start immediately and catch auth errors reactively on the first message                                                   
                                                                                             
The fix replaces the expensive `gemini --prompt "test"` call with the fast file-existence check (`_check_gemini_auth_fast()`) that already existed in the class. This checks for `~/.gemini/oauth_creds.json` and `~/.gemini/settings.json` that is sufficient to determine if the user has configured Gemini, without making an API call. The following video shows that the response time is improved, e.g., for the first call, down to 5 seconds from 12 seconds before the fix. 

https://github.com/user-attachments/assets/9fdbf9bc-30f2-4094-873f-667bcfdc2ae0

There was a lot of extra code in the `gemini.py` file, which is now removed. Also rechecked that after `/auth signout`, calling the Gemini persona will open a terminal in JupyterLab to authenticate Gemini with your Google account. 
