### PR TITLE
Avoid sending empty messages

### DIFF
--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -291,8 +291,7 @@ class BaseAcpPersona(BasePersona):
 
         client = await self.get_client()
         session_id = await self.get_session_id()
-
-        prompt = message.body.replace("@" + self.as_user().mention_name, "").strip()
+        prompt = message.body.strip()
 
         if self._pending_session_recovery_context:
             self._pending_session_recovery_context = False

--- a/jupyter_ai_acp_client/tests/test_base_acp_persona.py
+++ b/jupyter_ai_acp_client/tests/test_base_acp_persona.py
@@ -93,6 +93,25 @@ def _make_session_init_persona(
 class TestProcessMessageAttachments:
     """Tests for how process_message resolves attachments and calls prompt_and_reply."""
 
+    async def test_empty_message(self):
+        """
+        Ensure that bare @-mentions messages include content.
+        Prevents #111.
+        """
+        client = _make_client()
+        persona = _make_persona()
+        persona.get_client.return_value = client
+        msg = _make_message("@bot")
+
+        await BaseAcpPersona.process_message(persona, msg)
+
+        client.prompt_and_reply.assert_called_once_with(
+            session_id="sess-1",
+            prompt="@bot",
+            attachments=None,
+            root_dir="/home/user/notebooks",
+        )
+
     async def test_no_attachments(self):
         """When message has no attachments, prompt_and_reply is called without them."""
         client = _make_client()
@@ -104,7 +123,7 @@ class TestProcessMessageAttachments:
 
         client.prompt_and_reply.assert_called_once_with(
             session_id="sess-1",
-            prompt="hello",
+            prompt="@bot hello",
             attachments=None,
             root_dir="/home/user/notebooks",
         )
@@ -252,7 +271,7 @@ class TestLoadSessionRecovery:
         await BaseAcpPersona.process_message(persona, msg2)
 
         second_call_prompt = client.prompt_and_reply.call_args_list[1].kwargs["prompt"]
-        assert second_call_prompt == "second"
+        assert second_call_prompt == "@bot second"
 
     def test_build_history_context_excludes_current_message(self):
         """The current message is not included in the injected history."""


### PR DESCRIPTION
## Description

Fixes #111. 

Previously we always stripped the `@`-mention from the message. However, this causes an irrecoverable session error for some agents like Claude. The simplest fix is to drop this logic: empty messages now just tell the agent the user wants something to be done.




https://github.com/user-attachments/assets/4228a243-fe82-4dee-909c-56b909fadd9d

