### PR TITLE
Use fenced code blocks for login commands so copy button renders

### DIFF
--- a/jupyter_ai_acp_client/acp_personas/claude.py
+++ b/jupyter_ai_acp_client/acp_personas/claude.py
@@ -64,6 +64,7 @@ class ClaudeAcpPersona(BaseAcpPersona):
         # canned response and let the user choose for themselves.
         self.send_message(
             "You're not authenticated with Claude."
-            "\n\n- If you want to log in with a Claude.ai account, you may log in via `claude /login` in a new terminal."
+            "\n\n- If you want to log in with a Claude.ai account, run the following in a new terminal:"
+            "\n\n```\nclaude /login\n```"
             "\n\n- For cloud provider authentication and other options, see the [Claude.ai documentation](https://code.claude.com/docs/en/authentication)."
         )

--- a/jupyter_ai_acp_client/acp_personas/codex.py
+++ b/jupyter_ai_acp_client/acp_personas/codex.py
@@ -52,7 +52,9 @@ class CodexAcpPersona(BaseAcpPersona):
         self.send_message(
             "Codex isn't configured yet."
             "\n\n- Set `OPENAI_API_KEY` (or `CODEX_API_KEY`) before starting JupyterLab."
-            "\n\n- Or install the Codex CLI (`npm i -g @openai/codex`)"
-            " and run `codex login` to log in with your ChatGPT account."
+            "\n\n- Or install the Codex CLI:"
+            "\n\n```\nnpm i -g @openai/codex\n```"
+            "\n\nThen log in with your ChatGPT account:"
+            "\n\n```\ncodex login\n```"
             "\n\nRestart the JupyterLab server after either step."
         )

--- a/jupyter_ai_acp_client/acp_personas/copilot.py
+++ b/jupyter_ai_acp_client/acp_personas/copilot.py
@@ -78,7 +78,8 @@ class CopilotAcpPersona(BaseAcpPersona):
     async def handle_no_auth(self, message: Message) -> None:
         self.send_message(
             "GitHub Copilot isn't configured yet."
-            "\n\n- Run `copilot login` in a terminal to sign in with GitHub."
+            "\n\n- Run the following in a terminal to sign in with GitHub:"
+            "\n\n```\ncopilot login\n```"
             "\n\n- On headless or non-interactive setups, set `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN` before starting JupyterLab."
             "\n\n- Restart the JupyterLab server after changing Copilot CLI authentication or environment variables."
         )

--- a/jupyter_ai_acp_client/acp_personas/gemini.py
+++ b/jupyter_ai_acp_client/acp_personas/gemini.py
@@ -128,7 +128,7 @@ class GeminiAcpPersona(BaseAcpPersona):
 
     async def handle_no_auth(self, message: Message) -> None:
         # Return canned reply with setup instructions
-        self.send_message("You're not configured to use Gemini yet. Please run `gemini` in a terminal to complete the setup.")
+        self.send_message("You're not configured to use Gemini yet. Please run the following command in a terminal to complete the setup:\n\n```\ngemini\n```")
 
         # Open the terminal to help the user with setup
         if not self._terminal_opened:

--- a/jupyter_ai_acp_client/acp_personas/kiro.py
+++ b/jupyter_ai_acp_client/acp_personas/kiro.py
@@ -130,7 +130,7 @@ class KiroAcpPersona(BaseAcpPersona):
         command = "kiro-cli login --use-device-flow" if use_device_flow else "kiro-cli login"
         
         # Return canned reply with appropriate command
-        self.send_message(f"You're not signed in to Kiro yet. Please run `{command}` in a terminal to sign in.")
+        self.send_message(f"You're not signed in to Kiro yet. Please run the following command in a terminal to sign in:\n\n```\n{command}\n```")
 
         # Open the terminal to help the user login
         if not self._terminal_opened:


### PR DESCRIPTION

## Summary

Fixes #113

When a user is not authenticated, each agent persona shows a login command in an inline code block (single backticks). The markdown renderer adds a copy button to fenced code blocks but not inline code. This switches all runnable terminal commands to fenced code blocks so users can easily copy them.

## Changes

Updated `handle_no_auth()` in 5 persona files to use fenced code blocks for terminal commands:

- **kiro.py** — `kiro-cli login` / `kiro-cli login --use-device-flow`
- **claude.py** — `claude /login`
- **copilot.py** — `copilot login`
- **codex.py** — `npm i -g @openai/codex` and `codex login`
- **gemini.py** — `gemini`

Environment variable names (e.g., `OPENAI_API_KEY`) remain as inline code since they aren't runnable commands.

## Screenshot

<img width="1546" height="1980" alt="image" src="https://github.com/user-attachments/assets/e285144c-0489-4870-b8f8-7b91efc11ca6" />
