### PR TITLE
Proactively resume user request after signing in

### DIFF
--- a/jupyter_ai_acp_client/acp_personas/claude.py
+++ b/jupyter_ai_acp_client/acp_personas/claude.py
@@ -60,6 +60,7 @@ class ClaudeAcpPersona(BaseAcpPersona):
 
 
     async def handle_no_auth(self, message: Message) -> None:
+        await super().handle_no_auth(message)
         # Claude supports several authentication options so we just send a
         # canned response and let the user choose for themselves.
         self.send_message(

--- a/jupyter_ai_acp_client/acp_personas/claude.py
+++ b/jupyter_ai_acp_client/acp_personas/claude.py
@@ -13,6 +13,25 @@ from jupyterlab_chat.models import Message
 from acp.exceptions import RequestError
 
 from ..base_acp_persona import BaseAcpPersona
+
+
+def _is_auth_error(error: Exception) -> bool:
+    message = str(error).lower()
+    return any(
+        keyword in message
+        for keyword in (
+            "auth",
+            "login",
+            "not signed in",
+            "not authenticated",
+            "token",
+            "credential",
+            "forbidden",
+            "unauthorized",
+        )
+    )
+
+
 class ClaudeAcpPersona(BaseAcpPersona):
     def __init__(self, *args, **kwargs):
         executable = ["claude-agent-acp"]
@@ -52,7 +71,7 @@ class ClaudeAcpPersona(BaseAcpPersona):
         try:
             await super().process_message(message)
         except RequestError as e:
-            if "Authentication required" in str(e):
+            if _is_auth_error(e):
                 self.log.info("[Claude] User is not logged in.")
                 await self.handle_no_auth(message)
             else:

--- a/jupyter_ai_acp_client/acp_personas/codex.py
+++ b/jupyter_ai_acp_client/acp_personas/codex.py
@@ -49,6 +49,7 @@ class CodexAcpPersona(BaseAcpPersona):
             await self.handle_no_auth(message)
 
     async def handle_no_auth(self, message: Message) -> None:
+        await super().handle_no_auth(message)
         self.send_message(
             "Codex isn't configured yet."
             "\n\n- Set `OPENAI_API_KEY` (or `CODEX_API_KEY`) before starting JupyterLab."

--- a/jupyter_ai_acp_client/acp_personas/copilot.py
+++ b/jupyter_ai_acp_client/acp_personas/copilot.py
@@ -76,6 +76,7 @@ class CopilotAcpPersona(BaseAcpPersona):
             await self.handle_no_auth(message)
 
     async def handle_no_auth(self, message: Message) -> None:
+        await super().handle_no_auth(message)
         self.send_message(
             "GitHub Copilot isn't configured yet."
             "\n\n- Run the following in a terminal to sign in with GitHub:"

--- a/jupyter_ai_acp_client/acp_personas/gemini.py
+++ b/jupyter_ai_acp_client/acp_personas/gemini.py
@@ -111,11 +111,6 @@ class GeminiAcpPersona(BaseAcpPersona):
         # Reaching this point := user is authenticated
         self.log.info("[Gemini] User is signed in.")
 
-        # If initially signed out, send a message letting the user know they are
-        # now signed in.
-        if failed_auth_check:
-            self.send_message("Thanks for signing in! I'm ready to help.")
-
     async def is_authed(self) -> bool:
         # Check if the before_subprocess task is done (subprocess has started)
         if not self._before_subprocess_future.done():
@@ -127,6 +122,8 @@ class GeminiAcpPersona(BaseAcpPersona):
         return await self._check_gemini_auth_fast()
 
     async def handle_no_auth(self, message: Message) -> None:
+        await super().handle_no_auth(message)
+
         # Return canned reply with setup instructions
         self.send_message("You're not configured to use Gemini yet. Please run the following command in a terminal to complete the setup:\n\n```\ngemini\n```")
 

--- a/jupyter_ai_acp_client/acp_personas/goose.py
+++ b/jupyter_ai_acp_client/acp_personas/goose.py
@@ -130,6 +130,7 @@ class GooseAcpPersona(BaseAcpPersona):
             await self.handle_no_auth(message)
 
     async def handle_no_auth(self, message: Message) -> None:
+        await super().handle_no_auth(message)
         self.send_message(
             "Goose isn't configured yet."
             "\n\n- Run `goose configure` in a terminal to set up a provider."

--- a/jupyter_ai_acp_client/acp_personas/kiro.py
+++ b/jupyter_ai_acp_client/acp_personas/kiro.py
@@ -111,11 +111,6 @@ class KiroAcpPersona(BaseAcpPersona):
         
         # Reaching this point := user is authenticated
         self.log.info("[Kiro] User is signed in.")
-
-        # If initially signed out, send a message letting the user know they are
-        # now signed in.
-        if failed_auth_check:
-            self.send_message("Thanks for signing in! I'm ready to help.")
     
     async def is_authed(self) -> bool:
         # In Kiro, the user remains signed in even if they sign out while the
@@ -125,6 +120,8 @@ class KiroAcpPersona(BaseAcpPersona):
         return self._before_subprocess_future.done()
     
     async def handle_no_auth(self, message: Message) -> None:
+        await super().handle_no_auth(message)
+
         # Determine which command to show
         use_device_flow = await self._should_use_device_flow()
         command = "kiro-cli login --use-device-flow" if use_device_flow else "kiro-cli login"

--- a/jupyter_ai_acp_client/acp_personas/mistral_vibe.py
+++ b/jupyter_ai_acp_client/acp_personas/mistral_vibe.py
@@ -73,6 +73,7 @@ class MistralVibeAcpPersona(BaseAcpPersona):
             await self.handle_no_auth(message)
 
     async def handle_no_auth(self, message: Message) -> None:
+        await super().handle_no_auth(message)
         self.send_message(
             "Mistral Vibe isn't configured yet."
             "\n\n- Run `vibe --setup` in a terminal to configure your API key."

--- a/jupyter_ai_acp_client/acp_personas/opencode.py
+++ b/jupyter_ai_acp_client/acp_personas/opencode.py
@@ -146,6 +146,7 @@ class OpenCodeAcpPersona(BaseAcpPersona):
             await self.handle_no_auth(message)
 
     async def handle_no_auth(self, message: Message) -> None:
+        await super().handle_no_auth(message)
         self.send_message(
             "OpenCode isn't configured yet."
             "\n\n- Run `opencode auth` in a terminal to configure your LLM provider."

--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -68,6 +68,7 @@ class BaseAcpPersona(BasePersona):
 
         self._executable = executable
         self._pending_session_recovery_context: bool = False
+        self._was_initially_unauthenticated: bool = False
 
         # Ensure each subclass has its own subprocess and client by checking if the
         # class variable is defined directly on this class (not inherited)
@@ -202,7 +203,49 @@ class BaseAcpPersona(BasePersona):
                 self._pending_session_recovery_context = True
                 return await self._create_session(client)
         else:
-            return await self._create_session(client)
+            response = await self._create_session(client)
+
+            # After creating a new session, if the user was initially
+            # unauthenticated, proactively ask if they want to continue with
+            # their original request. Only the first instance to reach here
+            # should send the resume prompt.
+            if self._was_initially_unauthenticated:
+                self._was_initially_unauthenticated = False
+                await self._resume_after_auth(client, response.session_id)
+
+            return response
+
+    async def _resume_after_auth(
+        self, client: JaiAcpClient, session_id: str
+    ) -> None:
+        """
+        After the user signs in, send a hidden prompt with chat history so the
+        agent can proactively offer to continue with the user's original request.
+        """
+        history = self._build_history_context(
+            preamble=(
+                "You just became available after the user signed in. "
+                "Here are the messages they sent while you were unavailable:"
+            )
+        )
+        if history:
+            prompt = (
+                history + "\n\n"
+                "If the user made a request, ask them if they'd like you to "
+                "proceed with it. Otherwise, greet them and let them know "
+                "you're ready to help."
+            )
+        else:
+            prompt = (
+                "You just became available after the user signed in. "
+                "Greet them and let them know you're ready to help."
+            )
+
+        await client.prompt_and_reply(
+            session_id=session_id,
+            prompt=prompt,
+            root_dir=self.parent.root_dir,
+        )
 
     async def get_agent_subprocess(self) -> asyncio.subprocess.Process:
         """
@@ -243,17 +286,30 @@ class BaseAcpPersona(BasePersona):
     async def handle_no_auth(self, message: Message) -> None:
         """
         Method called when the persona receives a message while the user is not
-        authenticated. This method should return a canned response to the chat
-        asking the user to log in. Subclasses may override this method to
-        customize the help message sent.
-        """
-        self.send_message("You are not authenticated. Please log in.")
+        authenticated. Sets the `_was_initially_unauthenticated` flag so the
+        agent can proactively resume the user's request after signing in.
 
-    def _build_history_context(self, exclude_id: str | None = None) -> str:
+        Subclasses should call `await super().handle_no_auth(message)` first,
+        then send a custom message asking the user to log in and perform any
+        additional setup (e.g. opening a login terminal).
         """
-        Builds a plain-text summary of recent chat history for context injection
-        after load-session recovery. Caps at _MAX_HISTORY_MESSAGES to avoid
-        exceeding agent context window limits.
+        self._was_initially_unauthenticated = True
+        self.log.warning(
+            "[%s] Received message while unauthenticated.", self.__class__.__name__
+        )
+
+    def _build_history_context(
+        self,
+        exclude_id: str | None = None,
+        preamble: str = (
+            "The previous ACP session could not be loaded. Use this recent chat "
+            "transcript as historical context for continuity."
+        ),
+    ) -> str:
+        """
+        Builds a plain-text summary of recent chat history for context injection.
+        Caps at _MAX_HISTORY_MESSAGES to avoid exceeding agent context window
+        limits.
         """
         all_messages = self.ychat.get_messages()
         recent = [
@@ -269,8 +325,7 @@ class BaseAcpPersona(BasePersona):
             name = user.display_name if user else msg.sender
             lines.append(f"{name}: {msg.body}")
         return (
-            "The previous ACP session could not be loaded. Use this recent chat "
-            "transcript as historical context for continuity.\n"
+            preamble + "\n"
             "<conversation_history>\n"
             + "\n".join(lines)
             + "\n</conversation_history>"

--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -205,10 +205,9 @@ class BaseAcpPersona(BasePersona):
         else:
             response = await self._create_session(client)
 
-            # After creating a new session, if the user was initially
-            # unauthenticated, proactively ask if they want to continue with
-            # their original request. Only the first instance to reach here
-            # should send the resume prompt.
+            # If the user was initially unauthenticated and the session was
+            # blocked on auth (e.g. Kiro, Gemini), proactively resume their
+            # original request now that the session is ready.
             if self._was_initially_unauthenticated:
                 self._was_initially_unauthenticated = False
                 await self._resume_after_auth(client, response.session_id)
@@ -342,6 +341,15 @@ class BaseAcpPersona(BasePersona):
         # If not authenticated, return early
         if not await self.is_authed():
             await self.handle_no_auth(message)
+            return
+
+        # If the user was previously unauthenticated, proactively resume their
+        # original request instead of processing this message normally.
+        if self._was_initially_unauthenticated:
+            self._was_initially_unauthenticated = False
+            client = await self.get_client()
+            session_id = await self.get_session_id()
+            await self._resume_after_auth(client, session_id)
             return
 
         client = await self.get_client()

--- a/jupyter_ai_acp_client/tests/test_base_acp_persona.py
+++ b/jupyter_ai_acp_client/tests/test_base_acp_persona.py
@@ -21,6 +21,7 @@ def _make_persona(attachments_map: dict | None = None):
     persona.get_session_id = AsyncMock(return_value="sess-1")
     persona.is_authed = AsyncMock(return_value=True)
     persona._pending_session_recovery_context = False
+    persona._was_initially_unauthenticated = False
 
     # as_user() is sync — must return a regular MagicMock
     user_mock = MagicMock()

--- a/jupyter_ai_acp_client/tests/test_base_acp_persona.py
+++ b/jupyter_ai_acp_client/tests/test_base_acp_persona.py
@@ -343,33 +343,68 @@ class TestLoadSessionRecovery:
 
 
 class TestResumeAfterAuth:
-    """Tests for proactive resume after user signs in."""
+    """Tests for proactive resume after user signs in.
 
-    async def test_resume_in_process_message_for_preexisting_session(self):
-        """Agents with pre-existing sessions resume via process_message."""
+    There are two categories of ACP agents with respect to authentication:
+
+    **Agents with auth-gated sessions** (e.g. Kiro, Gemini): These agents cannot
+    start their ACP subprocess until the user is authenticated. The subprocess
+    startup is blocked in `before_agent_subprocess()`, which means
+    `_init_client_session()` does not complete until auth passes. Once the user
+    signs in, the session is created automatically and `_resume_after_auth()`
+    fires immediately — no new user message is needed to trigger it.
+
+    **Agents without auth-gated sessions** (e.g. Claude, Codex, Copilot): These
+    agents can start their subprocess and create a session without
+    authentication. Auth errors are only detected at prompt time — when
+    `process_message()` calls `prompt_and_reply()` and the agent raises a
+    RequestError. Because the session already exists, `_init_client_session()`
+    has long since completed. The resume logic must therefore run in
+    `process_message()`: on the first message after auth succeeds (i.e. the flag
+    is set and `is_authed()` returns True), `_resume_after_auth()` fires instead
+    of processing the message normally.
+    """
+
+    async def test_resume_for_agents_without_auth_gated_sessions(self):
+        """Agents without auth-gated sessions resume via process_message,
+        and the prompt includes the user's original message from chat history."""
         client = _make_client()
         persona = _make_persona()
         persona._was_initially_unauthenticated = True
         persona._MAX_HISTORY_MESSAGES = BaseAcpPersona._MAX_HISTORY_MESSAGES
         persona.get_client.return_value = client
+        # Simulate chat history: the user's original request is already in ychat,
+        # along with the new message that triggered process_message()
         persona.ychat.get_messages.return_value = [
-            _make_chat_message("msg-1", "please help me", "user-1"),
+            _make_chat_message("msg-1", "@Kiro generate a fibonacci file", "user-1"),
+            _make_chat_message("msg-2", "You're not signed in.", "bot-1"),
+            _make_chat_message("msg-3", "@Kiro hello again", "user-1"),
         ]
         persona.ychat.get_users.return_value = {}
         persona._build_history_context = (
             lambda **kw: BaseAcpPersona._build_history_context(persona, **kw)
         )
-        persona._resume_after_auth = AsyncMock()
+        # Let _resume_after_auth run for real (not mocked)
+        persona._resume_after_auth = (
+            lambda client, session_id: BaseAcpPersona._resume_after_auth(
+                persona, client, session_id
+            )
+        )
 
-        msg = _make_message("@bot hello")
+        # This message triggers process_message after auth passes
+        msg = _make_message("@bot hello again")
         await BaseAcpPersona.process_message(persona, msg)
 
-        # _resume_after_auth was called instead of prompt_and_reply
-        persona._resume_after_auth.assert_awaited_once_with(client, "sess-1")
-        client.prompt_and_reply.assert_not_called()
+        # prompt_and_reply was called with a prompt containing all chat history
+        # including the original request AND the latest triggering message
+        client.prompt_and_reply.assert_awaited_once()
+        prompt = client.prompt_and_reply.call_args.kwargs["prompt"]
+        assert "generate a fibonacci file" in prompt
+        assert "You're not signed in." in prompt
+        assert "hello again" in prompt
         assert persona._was_initially_unauthenticated is False
 
-    async def test_resume_in_process_message_only_fires_once(self):
+    async def test_resume_only_fires_once_for_agents_without_auth_gated_sessions(self):
         """The resume prompt only fires on the first message after auth."""
         client = _make_client()
         persona = _make_persona()
@@ -387,8 +422,11 @@ class TestResumeAfterAuth:
         persona._resume_after_auth.assert_awaited_once()
         client.prompt_and_reply.assert_awaited_once()
 
-    async def test_resume_in_init_client_session_for_auth_gated_agents(self):
-        """Auth-gated agents resume via _init_client_session after session creation."""
+    async def test_resume_for_agents_with_auth_gated_sessions(self):
+        """
+        Agents with auth-gated sessions automatically resume via
+        _init_client_session after session creation.
+        """
         persona, client = _make_session_init_persona(existing_session_id=None)
         persona._was_initially_unauthenticated = True
         persona._resume_after_auth = AsyncMock()

--- a/jupyter_ai_acp_client/tests/test_base_acp_persona.py
+++ b/jupyter_ai_acp_client/tests/test_base_acp_persona.py
@@ -340,3 +340,70 @@ class TestLoadSessionRecovery:
         assert "message 0" not in result
 
 
+
+
+class TestResumeAfterAuth:
+    """Tests for proactive resume after user signs in."""
+
+    async def test_resume_in_process_message_for_preexisting_session(self):
+        """Agents with pre-existing sessions resume via process_message."""
+        client = _make_client()
+        persona = _make_persona()
+        persona._was_initially_unauthenticated = True
+        persona._MAX_HISTORY_MESSAGES = BaseAcpPersona._MAX_HISTORY_MESSAGES
+        persona.get_client.return_value = client
+        persona.ychat.get_messages.return_value = [
+            _make_chat_message("msg-1", "please help me", "user-1"),
+        ]
+        persona.ychat.get_users.return_value = {}
+        persona._build_history_context = (
+            lambda **kw: BaseAcpPersona._build_history_context(persona, **kw)
+        )
+        persona._resume_after_auth = AsyncMock()
+
+        msg = _make_message("@bot hello")
+        await BaseAcpPersona.process_message(persona, msg)
+
+        # _resume_after_auth was called instead of prompt_and_reply
+        persona._resume_after_auth.assert_awaited_once_with(client, "sess-1")
+        client.prompt_and_reply.assert_not_called()
+        assert persona._was_initially_unauthenticated is False
+
+    async def test_resume_in_process_message_only_fires_once(self):
+        """The resume prompt only fires on the first message after auth."""
+        client = _make_client()
+        persona = _make_persona()
+        persona._was_initially_unauthenticated = True
+        persona.get_client.return_value = client
+        persona._resume_after_auth = AsyncMock()
+
+        msg1 = _make_message("@bot first")
+        await BaseAcpPersona.process_message(persona, msg1)
+
+        msg2 = _make_message("@bot second")
+        await BaseAcpPersona.process_message(persona, msg2)
+
+        # Resume called once, then normal prompt_and_reply on second message
+        persona._resume_after_auth.assert_awaited_once()
+        client.prompt_and_reply.assert_awaited_once()
+
+    async def test_resume_in_init_client_session_for_auth_gated_agents(self):
+        """Auth-gated agents resume via _init_client_session after session creation."""
+        persona, client = _make_session_init_persona(existing_session_id=None)
+        persona._was_initially_unauthenticated = True
+        persona._resume_after_auth = AsyncMock()
+
+        await BaseAcpPersona._init_client_session(persona)
+
+        persona._resume_after_auth.assert_awaited_once_with(client, "new-session")
+        assert persona._was_initially_unauthenticated is False
+
+    async def test_no_resume_when_not_initially_unauthenticated(self):
+        """No resume prompt when the user was authenticated from the start."""
+        persona, client = _make_session_init_persona(existing_session_id=None)
+        persona._was_initially_unauthenticated = False
+        persona._resume_after_auth = AsyncMock()
+
+        await BaseAcpPersona._init_client_session(persona)
+
+        persona._resume_after_auth.assert_not_awaited()

--- a/jupyter_ai_acp_client/tests/test_base_acp_persona.py
+++ b/jupyter_ai_acp_client/tests/test_base_acp_persona.py
@@ -68,6 +68,7 @@ def _make_session_init_persona(
     persona.id = "test-persona"
     persona.log = MagicMock()
     persona._pending_session_recovery_context = False
+    persona._was_initially_unauthenticated = False
 
     client = MagicMock()
     capabilities = MagicMock()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,12 +96,6 @@ before-build-python = ["jlpm clean:all"]
 [tool.check-wheel-contents]
 ignore = ["W002"]
 
-[dependency-groups]
-dev = [
-    "pytest>=9.0.3",
-    "pytest-jupyter>=0.11.0",
-]
-
 [project.entry-points."jupyter_ai.personas"]
 claude-acp = "jupyter_ai_acp_client.acp_personas.claude:ClaudeAcpPersona"
 kiro-acp = "jupyter_ai_acp_client.acp_personas.kiro:KiroAcpPersona"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,12 @@ before-build-python = ["jlpm clean:all"]
 [tool.check-wheel-contents]
 ignore = ["W002"]
 
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+    "pytest-jupyter>=0.11.0",
+]
+
 [project.entry-points."jupyter_ai.personas"]
 claude-acp = "jupyter_ai_acp_client.acp_personas.claude:ClaudeAcpPersona"
 kiro-acp = "jupyter_ai_acp_client.acp_personas.kiro:KiroAcpPersona"


### PR DESCRIPTION
## Summary

- Closes #115 
- Supersedes #114 

When a user sends a message while unauthenticated, the agent currently shows a "please log in" message. After signing in, it just says "Thanks for signing in! I'm ready to help." — completely forgetting the original request.

This PR makes the agent intelligently resume: after auth completes, it reads the chat history and proactively asks "Would you like me to proceed with [X]?" if there was a pending request.

## Changes

- **`base_acp_persona.py`**: Added `_was_initially_unauthenticated` instance flag, `_resume_after_auth()` method, refactored `_build_history_context()` to accept a custom preamble, and updated `handle_no_auth()` to set the flag (subclasses must call `super()`)
- **`kiro.py`** / **`gemini.py`**: Removed hard-coded "Thanks for signing in!" greeting; now call `await super().handle_no_auth(message)` before custom logic
- **All other personas** (`claude`, `codex`, `copilot`, `goose`, `opencode`, `mistral_vibe`): Added `await super().handle_no_auth(message)` call
- **`claude.py`**: Also added `_is_auth_error()` substring-based detection (matching copilot's pattern) to replace the narrow `"Authentication required"` check
- **`tests/test_base_acp_persona.py`**: Added 4 unit tests covering both resume paths

## How it works

Two paths to the same outcome, depending on the agent type:

**Agents with auth-gated sessions** (Kiro, Gemini) — subprocess blocked until auth:
1. User sends message → `handle_no_auth()` sets `_was_initially_unauthenticated = True`
2. Auth passes → subprocess starts → session created in `_init_client_session()`
3. `_init_client_session()` sees the flag, calls `_resume_after_auth()` proactively

**Agents without auth-gated sessions** (Claude, Codex, Copilot, etc.) — session already exists:
1. User sends message → auth error caught → `handle_no_auth()` sets the flag
2. User authenticates, sends another message (or same message retried)
3. `process_message()` sees the flag, calls `_resume_after_auth()` instead of processing normally

In both cases, `_resume_after_auth()` sends a hidden prompt with chat history to the agent, which decides whether to offer to continue with the user's request or just greet them.

## Demo with Kiro

To reproduce this:

1. Logout of Kiro (`kiro-cli logout`)
2. Open chat, send a message with a request
3. Log in thru new terminal
4. See that agent resumes intelligently

<img width="1062" height="678" alt="Screenshot 2026-05-18 at 1 27 55 PM" src="https://github.com/user-attachments/assets/8abf57b6-9de7-4dfe-9939-79de4934d94e" />

## Demo with Claude
