### PR TITLE
[WIP] Support Windows subprocess creation

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -1,0 +1,62 @@
+name: Test Windows
+
+on:
+  push:
+    branches: main
+  pull_request:
+    branches: '*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.12']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[test]
+
+      - name: Run tests
+        run: |
+          pytest -vv -r ap jupyter_ai_acp_client/tests/ -k "not integration"
+
+      - name: Verify Windows subprocess module imports
+        run: |
+          python -c "from jupyter_ai_acp_client._win32_subprocess import WindowsProcess, create_subprocess_windows; print('OK')"
+
+      - name: Test Windows subprocess creation with SelectorEventLoop
+        run: |
+          python -c "
+          import asyncio
+          import sys
+
+          # Force SelectorEventLoop like Tornado does on Windows
+          asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+          async def test():
+              from jupyter_ai_acp_client._win32_subprocess import create_subprocess_windows
+              proc = await create_subprocess_windows(
+                  sys.executable, '-c', 'import sys; sys.stdout.buffer.write(b\"hello\\n\"); sys.stdout.flush()'
+              )
+              line = await proc.stdout.readline()
+              assert line == b'hello\\n', f'Expected b\"hello\\\\n\", got {line!r}'
+              await proc.wait()
+              print('Windows subprocess test passed!')
+
+          asyncio.run(test())
+          "

--- a/jupyter_ai_acp_client/_win32_subprocess.py
+++ b/jupyter_ai_acp_client/_win32_subprocess.py
@@ -1,0 +1,137 @@
+"""Windows-compatible subprocess wrapper that provides asyncio StreamReader/StreamWriter.
+
+On Windows with Tornado's SelectorEventLoop, asyncio.create_subprocess_exec() raises
+NotImplementedError because SelectorEventLoop doesn't support subprocess operations.
+This module provides a fallback that uses subprocess.Popen and bridges its pipes to
+asyncio.StreamReader/StreamWriter via background threads.
+"""
+
+import asyncio
+import subprocess
+import sys
+import threading
+from typing import Any, Optional
+
+
+class _WriteTransport(asyncio.Transport):
+    """Minimal asyncio.Transport wrapping a synchronous pipe for StreamWriter."""
+
+    def __init__(self, pipe, loop: asyncio.AbstractEventLoop):
+        super().__init__()
+        self._pipe = pipe
+        self._loop = loop
+        self._closing = False
+
+    def write(self, data: bytes) -> None:
+        if self._closing:
+            return
+        try:
+            self._pipe.write(data)
+            self._pipe.flush()
+        except OSError:
+            pass
+
+    def can_write_eof(self) -> bool:
+        return False
+
+    def is_closing(self) -> bool:
+        return self._closing
+
+    def close(self) -> None:
+        self._closing = True
+        try:
+            self._pipe.close()
+        except OSError:
+            pass
+
+    def get_extra_info(self, name: str, default=None):
+        return default
+
+
+class WindowsProcess:
+    """A subprocess.Popen wrapper that mimics asyncio.subprocess.Process.
+
+    Provides .stdin (asyncio.StreamWriter) and .stdout (asyncio.StreamReader)
+    compatible with ACP's ClientSideConnection isinstance checks.
+    """
+
+    def __init__(self, popen: subprocess.Popen, loop: asyncio.AbstractEventLoop):
+        self._popen = popen
+        self._loop = loop
+        self._reader = asyncio.StreamReader(limit=50 * 1024 * 1024)
+        self._reader_thread: Optional[threading.Thread] = None
+
+        # Build StreamWriter around stdin pipe
+        transport = _WriteTransport(popen.stdin, loop)
+        protocol = asyncio.StreamReaderProtocol(asyncio.StreamReader())
+        self._writer = asyncio.StreamWriter(transport, protocol, None, loop)
+
+        # Start background thread to feed stdout data into the StreamReader
+        self._reader_thread = threading.Thread(
+            target=self._read_stdout, daemon=True, name="acp-win32-stdout-reader"
+        )
+        self._reader_thread.start()
+
+    def _read_stdout(self) -> None:
+        """Background thread: reads from Popen.stdout and feeds asyncio.StreamReader."""
+        try:
+            while True:
+                data = self._popen.stdout.read(65536)
+                if not data:
+                    break
+                self._loop.call_soon_threadsafe(self._reader.feed_data, data)
+        except (OSError, ValueError):
+            pass
+        finally:
+            self._loop.call_soon_threadsafe(self._reader.feed_eof)
+
+    @property
+    def stdin(self) -> asyncio.StreamWriter:
+        return self._writer
+
+    @property
+    def stdout(self) -> asyncio.StreamReader:
+        return self._reader
+
+    @property
+    def pid(self) -> int:
+        return self._popen.pid
+
+    @property
+    def returncode(self) -> Optional[int]:
+        return self._popen.returncode
+
+    async def wait(self) -> int:
+        """Wait for the process to exit."""
+        return await self._loop.run_in_executor(None, self._popen.wait)
+
+    def terminate(self) -> None:
+        self._popen.terminate()
+
+    def kill(self) -> None:
+        self._popen.kill()
+
+
+async def create_subprocess_windows(
+    *args: str,
+    stdin: Any = None,
+    stdout: Any = None,
+    stderr: Any = None,
+    limit: int = 50 * 1024 * 1024,
+    env: Optional[dict[str, str]] = None,
+    **kwargs: Any,
+) -> WindowsProcess:
+    """Create a subprocess on Windows using Popen, returning a WindowsProcess
+    that provides asyncio.StreamReader/StreamWriter for ACP compatibility."""
+    loop = asyncio.get_event_loop()
+    popen_kwargs: dict[str, Any] = dict(
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=stderr if stderr is not None else sys.stderr,
+        bufsize=0,
+        creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+    )
+    if env is not None:
+        popen_kwargs["env"] = env
+    popen = subprocess.Popen(list(args), **popen_kwargs)
+    return WindowsProcess(popen, loop)

--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -4,7 +4,7 @@ import signal
 import sys
 from asyncio import Task
 from asyncio.subprocess import Process
-from typing import Any, ClassVar, Optional
+from typing import Any, ClassVar, Optional, TYPE_CHECKING, Union
 
 from acp import NewSessionResponse, LoadSessionResponse
 from acp.schema import AvailableCommand
@@ -13,6 +13,9 @@ from jupyterlab_chat.models import Message
 
 from .default_acp_client import JaiAcpClient
 from .telemetry import emit_event, auto_emit_event
+
+if TYPE_CHECKING:
+    from ._win32_subprocess import WindowsProcess
 
 
 class BaseAcpPersona(BasePersona):
@@ -125,7 +128,21 @@ class BaseAcpPersona(BasePersona):
         )
         if env is not None:
             kwargs["env"] = env
-        process = await asyncio.create_subprocess_exec(*self._executable, **kwargs)
+        try:
+            process = await asyncio.create_subprocess_exec(*self._executable, **kwargs)
+        except NotImplementedError:
+            # Windows with SelectorEventLoop (e.g. Tornado) doesn't support
+            # asyncio subprocess creation. Fall back to Popen-based wrapper.
+            from ._win32_subprocess import create_subprocess_windows
+
+            self.log.info(
+                "asyncio subprocess not supported on this event loop; "
+                "using Windows fallback for '%s'.",
+                self.__class__.__name__,
+            )
+            process = await create_subprocess_windows(
+                *self._executable, stderr=sys.stderr, env=env
+            )
         self.log.info("Spawned ACP agent subprocess for '%s'.", self.__class__.__name__)
         return process
 
@@ -204,7 +221,7 @@ class BaseAcpPersona(BasePersona):
         else:
             return await self._create_session(client)
 
-    async def get_agent_subprocess(self) -> asyncio.subprocess.Process:
+    async def get_agent_subprocess(self) -> Union[Process, "WindowsProcess"]:
         """
         Safely returns the ACP agent subprocess for this persona.
         """
@@ -420,21 +437,36 @@ class BaseAcpPersona(BasePersona):
         # Step 3: Stop the subprocess gracefully, falling back to SIGKILL
         try:
             subprocess = await self.get_agent_subprocess()
-            pgid = os.getpgid(subprocess.pid)
-            os.killpg(pgid, signal.SIGINT)
-            os.killpg(pgid, signal.SIGTERM)
-            try:
-                await asyncio.wait_for(subprocess.wait(), timeout=5.0)
-                self.log.info(
-                    "[shutdown] Step 3: subprocess terminated for '%s'.",
-                    self.__class__.__name__,
-                )
-            except asyncio.TimeoutError:
-                os.killpg(pgid, signal.SIGKILL)
-                self.log.info(
-                    "[shutdown] Step 3: subprocess killed after timeout for '%s'.",
-                    self.__class__.__name__,
-                )
+            if sys.platform == "win32":
+                subprocess.terminate()
+                try:
+                    await asyncio.wait_for(subprocess.wait(), timeout=5.0)
+                    self.log.info(
+                        "[shutdown] Step 3: subprocess terminated for '%s'.",
+                        self.__class__.__name__,
+                    )
+                except asyncio.TimeoutError:
+                    subprocess.kill()
+                    self.log.info(
+                        "[shutdown] Step 3: subprocess killed after timeout for '%s'.",
+                        self.__class__.__name__,
+                    )
+            else:
+                pgid = os.getpgid(subprocess.pid)
+                os.killpg(pgid, signal.SIGINT)
+                os.killpg(pgid, signal.SIGTERM)
+                try:
+                    await asyncio.wait_for(subprocess.wait(), timeout=5.0)
+                    self.log.info(
+                        "[shutdown] Step 3: subprocess terminated for '%s'.",
+                        self.__class__.__name__,
+                    )
+                except asyncio.TimeoutError:
+                    os.killpg(pgid, signal.SIGKILL)
+                    self.log.info(
+                        "[shutdown] Step 3: subprocess killed after timeout for '%s'.",
+                        self.__class__.__name__,
+                    )
         except asyncio.CancelledError:
             pass
         except (ProcessLookupError, PermissionError, OSError):

--- a/jupyter_ai_acp_client/default_acp_client.py
+++ b/jupyter_ai_acp_client/default_acp_client.py
@@ -55,6 +55,10 @@ from jupyter_ai_persona_manager import BasePersona, McpServerStdio
 from jupyterlab_chat.models import Message
 from jupyterlab_chat.utils import find_mentions
 from asyncio.subprocess import Process
+from typing import Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ._win32_subprocess import WindowsProcess
 
 from .terminal_manager import TerminalManager
 from .tool_call_manager import ToolCallManager
@@ -70,7 +74,7 @@ class JaiAcpClient(Client):
     exactly one ACP client (an instance of this class).
     """
 
-    agent_subprocess: Process
+    agent_subprocess: Union[Process, "WindowsProcess"]
     _connection_future: Awaitable[tuple[ClientSideConnection, InitializeResponse]]
     event_loop: asyncio.AbstractEventLoop
     _personas_by_session: dict[str, BasePersona]
@@ -87,13 +91,13 @@ class JaiAcpClient(Client):
     def __init__(
             self,
             *args,
-            agent_subprocess: Awaitable[Process],
+            agent_subprocess: Union[Process, "WindowsProcess"],
             event_loop: asyncio.AbstractEventLoop,
             **kwargs,
     ):
         """
         :param agent_subprocess: The ACP agent subprocess
-        (`asyncio.subprocess.Process`) assigned to this client.
+        (`asyncio.subprocess.Process` or `WindowsProcess`) assigned to this client.
 
         :param event_loop: The `asyncio` event loop running this process.
         """

--- a/jupyter_ai_acp_client/terminal_manager.py
+++ b/jupyter_ai_acp_client/terminal_manager.py
@@ -5,6 +5,7 @@ import logging
 import os
 import shlex
 import signal as signal_module
+import sys
 import uuid
 from asyncio.subprocess import Process
 from dataclasses import dataclass, field
@@ -302,6 +303,24 @@ class TerminalManager:
                 stderr=asyncio.subprocess.STDOUT,  # Merge stderr into stdout
                 start_new_session=True,  # New process group for clean kill
             )
+        except NotImplementedError:
+            # Windows with SelectorEventLoop (e.g. Tornado) doesn't support
+            # asyncio subprocess creation. Fall back to subprocess.Popen.
+            import subprocess as _subprocess
+
+            popen_kwargs: dict[str, Any] = dict(
+                cwd=cwd,
+                env=env_dict,
+                stdin=_subprocess.DEVNULL,
+                stdout=_subprocess.PIPE,
+                stderr=_subprocess.STDOUT,
+                bufsize=0,
+                creationflags=getattr(_subprocess, "CREATE_NO_WINDOW", 0),
+            )
+            popen_proc = _subprocess.Popen(cmd_args, **popen_kwargs)
+            from ._win32_subprocess import WindowsProcess
+
+            process = WindowsProcess(popen_proc, self._event_loop)
         except FileNotFoundError:
             raise RequestError.invalid_params(
                 {"command": f"command not found: {command}"}
@@ -395,7 +414,10 @@ class TerminalManager:
         if info.process.returncode is None:
             # Kill the entire process group so child processes are cleaned up.
             try:
-                os.killpg(os.getpgid(info.process.pid), signal_module.SIGKILL)
+                if sys.platform == "win32":
+                    info.process.kill()
+                else:
+                    os.killpg(os.getpgid(info.process.pid), signal_module.SIGKILL)
             except (ProcessLookupError, PermissionError, OSError):
                 # Process already exited or is inaccessible — fall back to
                 # direct kill which is a no-op if already dead.
@@ -418,7 +440,10 @@ class TerminalManager:
         # Kill process if still running
         if info.process.returncode is None:
             try:
-                os.killpg(os.getpgid(info.process.pid), signal_module.SIGKILL)
+                if sys.platform == "win32":
+                    info.process.kill()
+                else:
+                    os.killpg(os.getpgid(info.process.pid), signal_module.SIGKILL)
             except (ProcessLookupError, PermissionError, OSError):
                 info.process.kill()
             await info.process.wait()


### PR DESCRIPTION
## Summary

Fixes #100 — `NotImplementedError` on Windows when `asyncio.create_subprocess_exec` is called under Tornado's `SelectorEventLoop`.

On Windows, Tornado forces `SelectorEventLoop` (it needs `add_reader` which `ProactorEventLoop` doesn't support). But `asyncio.create_subprocess_exec` only works with `ProactorEventLoop`, so all ACP persona subprocess creation fails.

## Approach

Catch `NotImplementedError` and fall back to `subprocess.Popen` wrapped in a `WindowsProcess` class that bridges the synchronous pipes to real `asyncio.StreamReader`/`StreamWriter` via a background reader thread. This is necessary because the ACP SDK's `ClientSideConnection` does an explicit `isinstance` check for these types.

Inspired by the [MCP Python SDK's solution](https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/os/win32/utilities.py), adapted to produce native asyncio streams instead of anyio streams.

## Changes

| File | What |
|------|------|
| `_win32_subprocess.py` | New module: `WindowsProcess` class + `create_subprocess_windows` helper |
| `base_acp_persona.py` | Fallback in `_init_agent_subprocess()`; platform-aware shutdown |
| `terminal_manager.py` | Same fallback for terminal subprocesses; platform-aware kill |
| `default_acp_client.py` | Type annotations updated |
| `.github/workflows/test-windows.yml` | New CI workflow for Windows (Python 3.10 + 3.12) |

## Testing

- All 252 existing tests pass (no regressions)
- Functional tests confirm `WindowsProcess` produces real `asyncio.StreamReader`/`StreamWriter` that pass `isinstance` checks
- CI workflow includes a test that forces `SelectorEventLoop` and verifies subprocess creation works
