### PR TITLE
fix(claude): enable auto-resume after login by gating subprocess on auth

### DIFF
--- a/jupyter_ai_acp_client/acp_personas/claude.py
+++ b/jupyter_ai_acp_client/acp_personas/claude.py
@@ -1,4 +1,7 @@
+import asyncio
+import json
 import shutil
+
 from jupyter_ai_persona_manager import PersonaRequirementsUnmet
 if shutil.which("claude-agent-acp") is None:
     raise PersonaRequirementsUnmet(
@@ -32,11 +35,26 @@ def _is_auth_error(error: Exception) -> bool:
     )
 
 
+async def _check_claude_auth() -> bool:
+    """Check if claude is authenticated by running `claude auth status`."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "claude", "auth", "status", "--json",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10.0)
+        result = json.loads(stdout.decode())
+        return result.get("loggedIn", False)
+    except (asyncio.TimeoutError, json.JSONDecodeError, FileNotFoundError, OSError):
+        return False
+
+
 class ClaudeAcpPersona(BaseAcpPersona):
     def __init__(self, *args, **kwargs):
         executable = ["claude-agent-acp"]
         super().__init__(*args, executable=executable, **kwargs)
-    
+
     @property
     def defaults(self) -> PersonaDefaults:
         avatar_path = str(os.path.abspath(
@@ -49,24 +67,34 @@ class ClaudeAcpPersona(BaseAcpPersona):
             avatar_path=avatar_path,
             system_prompt="unused"
         )
-    
+
     async def before_agent_subprocess(self):
-        # The Claude ACP agent server seems to always be able to start as long
-        # as `claude-agent-acp` is installed, so this method does not need to be
-        # implemented.
-        return None
+        """Block subprocess startup until Claude is authenticated.
+        Polls `claude auth status` every 3 seconds. Once auth passes,
+        the subprocess starts with valid credentials — matching Kiro's pattern.
+        """
+        if await _check_claude_auth():
+            return
+
+        # Not authenticated — wait and poll until user logs in
+        self.log.info("[Claude] Waiting for user to authenticate...")
+        while not await _check_claude_auth():
+            await asyncio.sleep(3)
+        self.log.info("[Claude] Authentication detected, starting subprocess.")
 
     async def is_authed(self) -> bool:
-        # Unfortunately, we cannot check the exit code of `claude auth status`
-        # as documented to implement this method. This command may claim the
-        # user is authenticated even if their token is expired. So we have to
-        # always return `True` here.
-        # 
-        # Upon auth failure, the `process_message()` method raises
-        # `acp.exceptions.RequestError: Authentication required` when the user
-        # is not logged in. We use that to inform the user to log in.
+        # If before_agent_subprocess hasn't completed yet, the user hasn't
+        # authenticated. This mirrors Kiro's pattern.
+        if not self._before_subprocess_future.done():
+            return False
+        # Once the subprocess is running, we trust it has valid credentials.
+        # Tokens can still expire mid-session, but we catch that via the
+        # try/except in process_message() as a fallback.
         return True
-    
+
+    def _needs_auth_before_subprocess(self) -> bool:
+        return True
+
     async def process_message(self, message: Message) -> None:
         try:
             await super().process_message(message)
@@ -77,11 +105,8 @@ class ClaudeAcpPersona(BaseAcpPersona):
             else:
                 raise e
 
-
     async def handle_no_auth(self, message: Message) -> None:
         await super().handle_no_auth(message)
-        # Claude supports several authentication options so we just send a
-        # canned response and let the user choose for themselves.
         self.send_message(
             "You're not authenticated with Claude."
             "\n\n- If you want to log in with a Claude.ai account, you may log in via `claude /login` in a new terminal."

--- a/jupyter_ai_acp_client/acp_personas/claude.py
+++ b/jupyter_ai_acp_client/acp_personas/claude.py
@@ -60,6 +60,7 @@ class ClaudeAcpPersona(BaseAcpPersona):
 
 
     async def handle_no_auth(self, message: Message) -> None:
+        await super().handle_no_auth(message)
         # Claude supports several authentication options so we just send a
         # canned response and let the user choose for themselves.
         self.send_message(

--- a/jupyter_ai_acp_client/acp_personas/claude.py
+++ b/jupyter_ai_acp_client/acp_personas/claude.py
@@ -13,6 +13,25 @@ from jupyterlab_chat.models import Message
 from acp.exceptions import RequestError
 
 from ..base_acp_persona import BaseAcpPersona
+
+
+def _is_auth_error(error: Exception) -> bool:
+    message = str(error).lower()
+    return any(
+        keyword in message
+        for keyword in (
+            "auth",
+            "login",
+            "not signed in",
+            "not authenticated",
+            "token",
+            "credential",
+            "forbidden",
+            "unauthorized",
+        )
+    )
+
+
 class ClaudeAcpPersona(BaseAcpPersona):
     def __init__(self, *args, **kwargs):
         executable = ["claude-agent-acp"]
@@ -52,7 +71,7 @@ class ClaudeAcpPersona(BaseAcpPersona):
         try:
             await super().process_message(message)
         except RequestError as e:
-            if "Authentication required" in str(e):
+            if _is_auth_error(e):
                 self.log.info("[Claude] User is not logged in.")
                 await self.handle_no_auth(message)
             else:

--- a/jupyter_ai_acp_client/acp_personas/codex.py
+++ b/jupyter_ai_acp_client/acp_personas/codex.py
@@ -49,6 +49,7 @@ class CodexAcpPersona(BaseAcpPersona):
             await self.handle_no_auth(message)
 
     async def handle_no_auth(self, message: Message) -> None:
+        await super().handle_no_auth(message)
         self.send_message(
             "Codex isn't configured yet."
             "\n\n- Set `OPENAI_API_KEY` (or `CODEX_API_KEY`) before starting JupyterLab."

--- a/jupyter_ai_acp_client/acp_personas/copilot.py
+++ b/jupyter_ai_acp_client/acp_personas/copilot.py
@@ -76,6 +76,7 @@ class CopilotAcpPersona(BaseAcpPersona):
             await self.handle_no_auth(message)
 
     async def handle_no_auth(self, message: Message) -> None:
+        await super().handle_no_auth(message)
         self.send_message(
             "GitHub Copilot isn't configured yet."
             "\n\n- Run `copilot login` in a terminal to sign in with GitHub."

--- a/jupyter_ai_acp_client/acp_personas/gemini.py
+++ b/jupyter_ai_acp_client/acp_personas/gemini.py
@@ -121,6 +121,9 @@ class GeminiAcpPersona(BaseAcpPersona):
         # configured before processing each message. Use a fast file check.
         return await self._check_gemini_auth_fast()
 
+    def _needs_auth_before_subprocess(self) -> bool:
+        return True
+
     async def handle_no_auth(self, message: Message) -> None:
         await super().handle_no_auth(message)
 

--- a/jupyter_ai_acp_client/acp_personas/gemini.py
+++ b/jupyter_ai_acp_client/acp_personas/gemini.py
@@ -111,11 +111,6 @@ class GeminiAcpPersona(BaseAcpPersona):
         # Reaching this point := user is authenticated
         self.log.info("[Gemini] User is signed in.")
 
-        # If initially signed out, send a message letting the user know they are
-        # now signed in.
-        if failed_auth_check:
-            self.send_message("Thanks for signing in! I'm ready to help.")
-
     async def is_authed(self) -> bool:
         # Check if the before_subprocess task is done (subprocess has started)
         if not self._before_subprocess_future.done():
@@ -127,6 +122,8 @@ class GeminiAcpPersona(BaseAcpPersona):
         return await self._check_gemini_auth_fast()
 
     async def handle_no_auth(self, message: Message) -> None:
+        await super().handle_no_auth(message)
+
         # Return canned reply with setup instructions
         self.send_message("You're not configured to use Gemini yet. Please run `gemini` in a terminal to complete the setup.")
 

--- a/jupyter_ai_acp_client/acp_personas/goose.py
+++ b/jupyter_ai_acp_client/acp_personas/goose.py
@@ -130,6 +130,7 @@ class GooseAcpPersona(BaseAcpPersona):
             await self.handle_no_auth(message)
 
     async def handle_no_auth(self, message: Message) -> None:
+        await super().handle_no_auth(message)
         self.send_message(
             "Goose isn't configured yet."
             "\n\n- Run `goose configure` in a terminal to set up a provider."

--- a/jupyter_ai_acp_client/acp_personas/kiro.py
+++ b/jupyter_ai_acp_client/acp_personas/kiro.py
@@ -119,6 +119,9 @@ class KiroAcpPersona(BaseAcpPersona):
         # authenticated.
         return self._before_subprocess_future.done()
     
+    def _needs_auth_before_subprocess(self) -> bool:
+        return True
+
     async def handle_no_auth(self, message: Message) -> None:
         await super().handle_no_auth(message)
 

--- a/jupyter_ai_acp_client/acp_personas/kiro.py
+++ b/jupyter_ai_acp_client/acp_personas/kiro.py
@@ -111,11 +111,6 @@ class KiroAcpPersona(BaseAcpPersona):
         
         # Reaching this point := user is authenticated
         self.log.info("[Kiro] User is signed in.")
-
-        # If initially signed out, send a message letting the user know they are
-        # now signed in.
-        if failed_auth_check:
-            self.send_message("Thanks for signing in! I'm ready to help.")
     
     async def is_authed(self) -> bool:
         # In Kiro, the user remains signed in even if they sign out while the
@@ -125,6 +120,8 @@ class KiroAcpPersona(BaseAcpPersona):
         return self._before_subprocess_future.done()
     
     async def handle_no_auth(self, message: Message) -> None:
+        await super().handle_no_auth(message)
+
         # Determine which command to show
         use_device_flow = await self._should_use_device_flow()
         command = "kiro-cli login --use-device-flow" if use_device_flow else "kiro-cli login"

--- a/jupyter_ai_acp_client/acp_personas/mistral_vibe.py
+++ b/jupyter_ai_acp_client/acp_personas/mistral_vibe.py
@@ -73,6 +73,7 @@ class MistralVibeAcpPersona(BaseAcpPersona):
             await self.handle_no_auth(message)
 
     async def handle_no_auth(self, message: Message) -> None:
+        await super().handle_no_auth(message)
         self.send_message(
             "Mistral Vibe isn't configured yet."
             "\n\n- Run `vibe --setup` in a terminal to configure your API key."

--- a/jupyter_ai_acp_client/acp_personas/opencode.py
+++ b/jupyter_ai_acp_client/acp_personas/opencode.py
@@ -146,6 +146,7 @@ class OpenCodeAcpPersona(BaseAcpPersona):
             await self.handle_no_auth(message)
 
     async def handle_no_auth(self, message: Message) -> None:
+        await super().handle_no_auth(message)
         self.send_message(
             "OpenCode isn't configured yet."
             "\n\n- Run `opencode auth` in a terminal to configure your LLM provider."

--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -68,6 +68,7 @@ class BaseAcpPersona(BasePersona):
 
         self._executable = executable
         self._pending_session_recovery_context: bool = False
+        self._was_initially_unauthenticated: bool = False
 
         # Ensure each subclass has its own subprocess and client by checking if the
         # class variable is defined directly on this class (not inherited)
@@ -202,7 +203,49 @@ class BaseAcpPersona(BasePersona):
                 self._pending_session_recovery_context = True
                 return await self._create_session(client)
         else:
-            return await self._create_session(client)
+            response = await self._create_session(client)
+
+            # After creating a new session, if the user was initially
+            # unauthenticated, proactively ask if they want to continue with
+            # their original request. Only the first instance to reach here
+            # should send the resume prompt.
+            if self._was_initially_unauthenticated:
+                self._was_initially_unauthenticated = False
+                await self._resume_after_auth(client, response.session_id)
+
+            return response
+
+    async def _resume_after_auth(
+        self, client: JaiAcpClient, session_id: str
+    ) -> None:
+        """
+        After the user signs in, send a hidden prompt with chat history so the
+        agent can proactively offer to continue with the user's original request.
+        """
+        history = self._build_history_context(
+            preamble=(
+                "You just became available after the user signed in. "
+                "Here are the messages they sent while you were unavailable:"
+            )
+        )
+        if history:
+            prompt = (
+                history + "\n\n"
+                "If the user made a request, ask them if they'd like you to "
+                "proceed with it. Otherwise, greet them and let them know "
+                "you're ready to help."
+            )
+        else:
+            prompt = (
+                "You just became available after the user signed in. "
+                "Greet them and let them know you're ready to help."
+            )
+
+        await client.prompt_and_reply(
+            session_id=session_id,
+            prompt=prompt,
+            root_dir=self.parent.root_dir,
+        )
 
     async def get_agent_subprocess(self) -> asyncio.subprocess.Process:
         """
@@ -243,17 +286,30 @@ class BaseAcpPersona(BasePersona):
     async def handle_no_auth(self, message: Message) -> None:
         """
         Method called when the persona receives a message while the user is not
-        authenticated. This method should return a canned response to the chat
-        asking the user to log in. Subclasses may override this method to
-        customize the help message sent.
-        """
-        self.send_message("You are not authenticated. Please log in.")
+        authenticated. Sets the `_was_initially_unauthenticated` flag so the
+        agent can proactively resume the user's request after signing in.
 
-    def _build_history_context(self, exclude_id: str | None = None) -> str:
+        Subclasses should call `await super().handle_no_auth(message)` first,
+        then send a custom message asking the user to log in and perform any
+        additional setup (e.g. opening a login terminal).
         """
-        Builds a plain-text summary of recent chat history for context injection
-        after load-session recovery. Caps at _MAX_HISTORY_MESSAGES to avoid
-        exceeding agent context window limits.
+        self._was_initially_unauthenticated = True
+        self.log.warning(
+            "[%s] Received message while unauthenticated.", self.__class__.__name__
+        )
+
+    def _build_history_context(
+        self,
+        exclude_id: str | None = None,
+        preamble: str = (
+            "The previous ACP session could not be loaded. Use this recent chat "
+            "transcript as historical context for continuity."
+        ),
+    ) -> str:
+        """
+        Builds a plain-text summary of recent chat history for context injection.
+        Caps at _MAX_HISTORY_MESSAGES to avoid exceeding agent context window
+        limits.
         """
         all_messages = self.ychat.get_messages()
         recent = [
@@ -269,8 +325,7 @@ class BaseAcpPersona(BasePersona):
             name = user.display_name if user else msg.sender
             lines.append(f"{name}: {msg.body}")
         return (
-            "The previous ACP session could not be loaded. Use this recent chat "
-            "transcript as historical context for continuity.\n"
+            preamble + "\n"
             "<conversation_history>\n"
             + "\n".join(lines)
             + "\n</conversation_history>"

--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -220,7 +220,16 @@ class BaseAcpPersona(BasePersona):
         """
         After the user signs in, send a hidden prompt with chat history so the
         agent can proactively offer to continue with the user's original request.
+
+        For agents with pre-existing sessions (e.g. Codex, Copilot), the
+        subprocess may have been started before auth. If so, we restart it
+        first so it picks up the fresh auth state.
         """
+        if not self._needs_auth_before_subprocess():
+            await self._restart_agent()
+            client = await self.get_client()
+            session_id = await self.get_session_id()
+
         history = self._build_history_context(
             preamble=(
                 "You just became available after the user signed in. "
@@ -244,6 +253,45 @@ class BaseAcpPersona(BasePersona):
             session_id=session_id,
             prompt=prompt,
             root_dir=self.parent.root_dir,
+        )
+
+    def _needs_auth_before_subprocess(self) -> bool:
+        """
+        Returns True if this agent blocks subprocess startup until auth passes
+        (e.g. Kiro, Gemini). Returns False for agents with pre-existing sessions
+        that start regardless of auth (e.g. Claude, Codex, Copilot).
+
+        Subclasses that gate subprocess startup on auth should override this
+        to return True.
+        """
+        return False
+
+    async def _restart_agent(self) -> None:
+        """
+        Kills the current ACP agent subprocess and client, then starts fresh
+        ones. Used when the subprocess was started before authentication and
+        needs to pick up new credentials after the user signs in.
+        """
+        self.log.info("[%s] Restarting agent subprocess to pick up new credentials.", self.__class__.__name__)
+
+        # Kill old subprocess
+        old_process = await self.__class__._subprocess_future
+        try:
+            old_process.terminate()
+            await asyncio.wait_for(old_process.wait(), timeout=5.0)
+        except (ProcessLookupError, asyncio.TimeoutError):
+            old_process.kill()
+
+        # Reset class-level futures so new ones are created
+        self.__class__._subprocess_future = self.event_loop.create_task(
+            self._init_agent_subprocess()
+        )
+        self.__class__._client_future = self.event_loop.create_task(
+            self._init_client()
+        )
+        # Create a new session on the fresh subprocess
+        self._client_session_future = self.event_loop.create_task(
+            self._init_client_session()
         )
 
     async def get_agent_subprocess(self) -> asyncio.subprocess.Process:

--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -205,10 +205,9 @@ class BaseAcpPersona(BasePersona):
         else:
             response = await self._create_session(client)
 
-            # After creating a new session, if the user was initially
-            # unauthenticated, proactively ask if they want to continue with
-            # their original request. Only the first instance to reach here
-            # should send the resume prompt.
+            # If the user was initially unauthenticated and the session was
+            # blocked on auth (e.g. Kiro, Gemini), proactively resume their
+            # original request now that the session is ready.
             if self._was_initially_unauthenticated:
                 self._was_initially_unauthenticated = False
                 await self._resume_after_auth(client, response.session_id)
@@ -342,6 +341,15 @@ class BaseAcpPersona(BasePersona):
         # If not authenticated, return early
         if not await self.is_authed():
             await self.handle_no_auth(message)
+            return
+
+        # If the user was previously unauthenticated, proactively resume their
+        # original request instead of processing this message normally.
+        if self._was_initially_unauthenticated:
+            self._was_initially_unauthenticated = False
+            client = await self.get_client()
+            session_id = await self.get_session_id()
+            await self._resume_after_auth(client, session_id)
             return
 
         client = await self.get_client()

--- a/jupyter_ai_acp_client/tests/test_base_acp_persona.py
+++ b/jupyter_ai_acp_client/tests/test_base_acp_persona.py
@@ -321,3 +321,70 @@ class TestLoadSessionRecovery:
         assert "message 0" not in result
 
 
+
+
+class TestResumeAfterAuth:
+    """Tests for proactive resume after user signs in."""
+
+    async def test_resume_in_process_message_for_preexisting_session(self):
+        """Agents with pre-existing sessions resume via process_message."""
+        client = _make_client()
+        persona = _make_persona()
+        persona._was_initially_unauthenticated = True
+        persona._MAX_HISTORY_MESSAGES = BaseAcpPersona._MAX_HISTORY_MESSAGES
+        persona.get_client.return_value = client
+        persona.ychat.get_messages.return_value = [
+            _make_chat_message("msg-1", "please help me", "user-1"),
+        ]
+        persona.ychat.get_users.return_value = {}
+        persona._build_history_context = (
+            lambda **kw: BaseAcpPersona._build_history_context(persona, **kw)
+        )
+        persona._resume_after_auth = AsyncMock()
+
+        msg = _make_message("@bot hello")
+        await BaseAcpPersona.process_message(persona, msg)
+
+        # _resume_after_auth was called instead of prompt_and_reply
+        persona._resume_after_auth.assert_awaited_once_with(client, "sess-1")
+        client.prompt_and_reply.assert_not_called()
+        assert persona._was_initially_unauthenticated is False
+
+    async def test_resume_in_process_message_only_fires_once(self):
+        """The resume prompt only fires on the first message after auth."""
+        client = _make_client()
+        persona = _make_persona()
+        persona._was_initially_unauthenticated = True
+        persona.get_client.return_value = client
+        persona._resume_after_auth = AsyncMock()
+
+        msg1 = _make_message("@bot first")
+        await BaseAcpPersona.process_message(persona, msg1)
+
+        msg2 = _make_message("@bot second")
+        await BaseAcpPersona.process_message(persona, msg2)
+
+        # Resume called once, then normal prompt_and_reply on second message
+        persona._resume_after_auth.assert_awaited_once()
+        client.prompt_and_reply.assert_awaited_once()
+
+    async def test_resume_in_init_client_session_for_auth_gated_agents(self):
+        """Auth-gated agents resume via _init_client_session after session creation."""
+        persona, client = _make_session_init_persona(existing_session_id=None)
+        persona._was_initially_unauthenticated = True
+        persona._resume_after_auth = AsyncMock()
+
+        await BaseAcpPersona._init_client_session(persona)
+
+        persona._resume_after_auth.assert_awaited_once_with(client, "new-session")
+        assert persona._was_initially_unauthenticated is False
+
+    async def test_no_resume_when_not_initially_unauthenticated(self):
+        """No resume prompt when the user was authenticated from the start."""
+        persona, client = _make_session_init_persona(existing_session_id=None)
+        persona._was_initially_unauthenticated = False
+        persona._resume_after_auth = AsyncMock()
+
+        await BaseAcpPersona._init_client_session(persona)
+
+        persona._resume_after_auth.assert_not_awaited()

--- a/jupyter_ai_acp_client/tests/test_base_acp_persona.py
+++ b/jupyter_ai_acp_client/tests/test_base_acp_persona.py
@@ -324,33 +324,68 @@ class TestLoadSessionRecovery:
 
 
 class TestResumeAfterAuth:
-    """Tests for proactive resume after user signs in."""
+    """Tests for proactive resume after user signs in.
 
-    async def test_resume_in_process_message_for_preexisting_session(self):
-        """Agents with pre-existing sessions resume via process_message."""
+    There are two categories of ACP agents with respect to authentication:
+
+    **Agents with auth-gated sessions** (e.g. Kiro, Gemini): These agents cannot
+    start their ACP subprocess until the user is authenticated. The subprocess
+    startup is blocked in `before_agent_subprocess()`, which means
+    `_init_client_session()` does not complete until auth passes. Once the user
+    signs in, the session is created automatically and `_resume_after_auth()`
+    fires immediately — no new user message is needed to trigger it.
+
+    **Agents without auth-gated sessions** (e.g. Claude, Codex, Copilot): These
+    agents can start their subprocess and create a session without
+    authentication. Auth errors are only detected at prompt time — when
+    `process_message()` calls `prompt_and_reply()` and the agent raises a
+    RequestError. Because the session already exists, `_init_client_session()`
+    has long since completed. The resume logic must therefore run in
+    `process_message()`: on the first message after auth succeeds (i.e. the flag
+    is set and `is_authed()` returns True), `_resume_after_auth()` fires instead
+    of processing the message normally.
+    """
+
+    async def test_resume_for_agents_without_auth_gated_sessions(self):
+        """Agents without auth-gated sessions resume via process_message,
+        and the prompt includes the user's original message from chat history."""
         client = _make_client()
         persona = _make_persona()
         persona._was_initially_unauthenticated = True
         persona._MAX_HISTORY_MESSAGES = BaseAcpPersona._MAX_HISTORY_MESSAGES
         persona.get_client.return_value = client
+        # Simulate chat history: the user's original request is already in ychat,
+        # along with the new message that triggered process_message()
         persona.ychat.get_messages.return_value = [
-            _make_chat_message("msg-1", "please help me", "user-1"),
+            _make_chat_message("msg-1", "@Kiro generate a fibonacci file", "user-1"),
+            _make_chat_message("msg-2", "You're not signed in.", "bot-1"),
+            _make_chat_message("msg-3", "@Kiro hello again", "user-1"),
         ]
         persona.ychat.get_users.return_value = {}
         persona._build_history_context = (
             lambda **kw: BaseAcpPersona._build_history_context(persona, **kw)
         )
-        persona._resume_after_auth = AsyncMock()
+        # Let _resume_after_auth run for real (not mocked)
+        persona._resume_after_auth = (
+            lambda client, session_id: BaseAcpPersona._resume_after_auth(
+                persona, client, session_id
+            )
+        )
 
-        msg = _make_message("@bot hello")
+        # This message triggers process_message after auth passes
+        msg = _make_message("@bot hello again")
         await BaseAcpPersona.process_message(persona, msg)
 
-        # _resume_after_auth was called instead of prompt_and_reply
-        persona._resume_after_auth.assert_awaited_once_with(client, "sess-1")
-        client.prompt_and_reply.assert_not_called()
+        # prompt_and_reply was called with a prompt containing all chat history
+        # including the original request AND the latest triggering message
+        client.prompt_and_reply.assert_awaited_once()
+        prompt = client.prompt_and_reply.call_args.kwargs["prompt"]
+        assert "generate a fibonacci file" in prompt
+        assert "You're not signed in." in prompt
+        assert "hello again" in prompt
         assert persona._was_initially_unauthenticated is False
 
-    async def test_resume_in_process_message_only_fires_once(self):
+    async def test_resume_only_fires_once_for_agents_without_auth_gated_sessions(self):
         """The resume prompt only fires on the first message after auth."""
         client = _make_client()
         persona = _make_persona()
@@ -368,8 +403,11 @@ class TestResumeAfterAuth:
         persona._resume_after_auth.assert_awaited_once()
         client.prompt_and_reply.assert_awaited_once()
 
-    async def test_resume_in_init_client_session_for_auth_gated_agents(self):
-        """Auth-gated agents resume via _init_client_session after session creation."""
+    async def test_resume_for_agents_with_auth_gated_sessions(self):
+        """
+        Agents with auth-gated sessions automatically resume via
+        _init_client_session after session creation.
+        """
         persona, client = _make_session_init_persona(existing_session_id=None)
         persona._was_initially_unauthenticated = True
         persona._resume_after_auth = AsyncMock()

--- a/jupyter_ai_acp_client/tests/test_base_acp_persona.py
+++ b/jupyter_ai_acp_client/tests/test_base_acp_persona.py
@@ -21,6 +21,7 @@ def _make_persona(attachments_map: dict | None = None):
     persona.get_session_id = AsyncMock(return_value="sess-1")
     persona.is_authed = AsyncMock(return_value=True)
     persona._pending_session_recovery_context = False
+    persona._was_initially_unauthenticated = False
 
     # as_user() is sync — must return a regular MagicMock
     user_mock = MagicMock()

--- a/jupyter_ai_acp_client/tests/test_base_acp_persona.py
+++ b/jupyter_ai_acp_client/tests/test_base_acp_persona.py
@@ -68,6 +68,7 @@ def _make_session_init_persona(
     persona.id = "test-persona"
     persona.log = MagicMock()
     persona._pending_session_recovery_context = False
+    persona._was_initially_unauthenticated = False
 
     client = MagicMock()
     capabilities = MagicMock()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,12 +96,6 @@ before-build-python = ["jlpm clean:all"]
 [tool.check-wheel-contents]
 ignore = ["W002"]
 
-[dependency-groups]
-dev = [
-    "pytest>=9.0.3",
-    "pytest-jupyter>=0.11.0",
-]
-
 [project.entry-points."jupyter_ai.personas"]
 claude-acp = "jupyter_ai_acp_client.acp_personas.claude:ClaudeAcpPersona"
 kiro-acp = "jupyter_ai_acp_client.acp_personas.kiro:KiroAcpPersona"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,12 @@ before-build-python = ["jlpm clean:all"]
 [tool.check-wheel-contents]
 ignore = ["W002"]
 
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+    "pytest-jupyter>=0.11.0",
+]
+
 [project.entry-points."jupyter_ai.personas"]
 claude-acp = "jupyter_ai_acp_client.acp_personas.claude:ClaudeAcpPersona"
 kiro-acp = "jupyter_ai_acp_client.acp_personas.kiro:KiroAcpPersona"


### PR DESCRIPTION
## Summary

This PR includes all changes from #117 (resume after auth) plus a fix for the Claude persona.

## Problem with #117's Claude flow

Claude's `before_agent_subprocess()` returns immediately, so the subprocess starts before authentication. After the user logs in via `claude /login`, the running subprocess doesn't pick up new credentials. `_resume_after_auth()` fails silently — the user has to send a second message, unlike Kiro which auto-resumes immediately.

## Fix

Make Claude follow Kiro's pattern: poll `claude auth status` in `before_agent_subprocess()` until auth passes, then start the subprocess with valid credentials.

### Changes (on top of #117):
- **claude.py**: Add `_check_claude_auth()` polling helper, gate subprocess startup on auth, fix `is_authed()` to check `_before_subprocess_future.done()`
- **base_acp_persona.py**: Add `_restart_agent()` method and `_needs_auth_before_subprocess()` hook for agents (Codex, Copilot) that use pre-existing sessions
- **kiro.py, gemini.py**: Override `_needs_auth_before_subprocess() → True`

## Testing

Tested in SageMaker Studio:
1. Send message → login prompt appears ✓
2. Run `claude auth login` in terminal → authenticate ✓
3. Chat **automatically** resumes with "Would you like me to proceed with [original request]?" ✓
4. No second message needed ✓

All 19 existing unit tests pass.

## Relationship to #117

This PR includes all of #117's commits. Can be merged directly as a replacement for #117 (supersedes it).