### PR TITLE
[WIP] Add REST endpoint to restart ACP agent subprocess

### DIFF
--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -410,6 +410,71 @@ class BaseAcpPersona(BasePersona):
         )
         self._acp_slash_commands = commands
 
+    async def restart(self) -> None:
+        """
+        Restart the ACP agent subprocess shared by all instances of this persona
+        class. Kills the existing subprocess, resets class-level futures, and
+        re-initializes the subprocess, client, and sessions for all active
+        persona instances.
+        """
+        self.log.info("[restart] Starting for '%s'.", self.__class__.__name__)
+
+        # Collect all persona instances that share this subprocess before teardown
+        siblings: list[BaseAcpPersona] = []
+        try:
+            client = await self.get_client()
+            for persona in client._personas_by_session.values():
+                if isinstance(persona, BaseAcpPersona) and persona not in siblings:
+                    siblings.append(persona)
+        except (asyncio.CancelledError, Exception):
+            siblings = [self]
+
+        # Step 1: Close connection
+        try:
+            client = await self.get_client()
+            conn = await client.get_connection()
+            await conn.close()
+        except (asyncio.CancelledError, Exception):
+            self.log.warning("[restart] Failed to close connection.", exc_info=True)
+
+        # Step 2: Kill subprocess
+        try:
+            subprocess = await self.get_agent_subprocess()
+            pgid = os.getpgid(subprocess.pid)
+            os.killpg(pgid, signal.SIGTERM)
+            try:
+                await asyncio.wait_for(subprocess.wait(), timeout=5.0)
+            except asyncio.TimeoutError:
+                os.killpg(pgid, signal.SIGKILL)
+        except (asyncio.CancelledError, ProcessLookupError, PermissionError, OSError):
+            pass
+        except Exception:
+            self.log.warning("[restart] Failed to kill subprocess.", exc_info=True)
+
+        # Step 3: Reset class-level futures
+        self.__class__._before_subprocess_future = None
+        self.__class__._subprocess_future = None
+        self.__class__._client_future = None
+
+        # Step 4: Re-initialize subprocess and client (class-level, done once)
+        self.__class__._before_subprocess_future = self.event_loop.create_task(
+            self.before_agent_subprocess()
+        )
+        self.__class__._subprocess_future = self.event_loop.create_task(
+            self._init_agent_subprocess()
+        )
+        self.__class__._client_future = self.event_loop.create_task(
+            self._init_client()
+        )
+
+        # Step 5: Re-initialize sessions for all sibling persona instances
+        for persona in siblings:
+            persona._client_session_future = persona.event_loop.create_task(
+                persona._init_client_session()
+            )
+
+        self.log.info("[restart] Complete for '%s'.", self.__class__.__name__)
+
     async def shutdown(self):
         if getattr(self, "_shutting_down", False):
             return

--- a/jupyter_ai_acp_client/extension_app.py
+++ b/jupyter_ai_acp_client/extension_app.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
 from jupyter_server.extension.application import ExtensionApp
-from .routes import AcpSlashCommandsHandler, PermissionHandler, StopStreamingHandler
+from .routes import AcpSlashCommandsHandler, PermissionHandler, RestartSubprocessHandler, StopStreamingHandler
 
 
 class JaiAcpClientExtension(ExtensionApp):
@@ -14,6 +14,7 @@ class JaiAcpClientExtension(ExtensionApp):
         (r"ai/acp/slash_commands/?([^/]*)?", AcpSlashCommandsHandler),
         (r"ai/acp/permissions", PermissionHandler),
         (r"ai/acp/stop/?([^/]*)?", StopStreamingHandler),
+        (r"ai/acp/restart", RestartSubprocessHandler),
     ]
 
     def initialize_settings(self):

--- a/jupyter_ai_acp_client/routes.py
+++ b/jupyter_ai_acp_client/routes.py
@@ -118,6 +118,44 @@ class StopStreamingHandler(APIHandler):
         self.finish({"status": "stopped", "stopped": stopped})
 
 
+class RestartSubprocessHandler(APIHandler):
+    """
+    REST endpoint to restart an ACP agent subprocess.
+    POST /ai/acp/restart?chat_path=<path>
+    Restarts the subprocess for all ACP personas in the given chat room.
+    """
+
+    @property
+    def file_id_manager(self) -> BaseFileIdManager:
+        manager = self.serverapp.web_app.settings["file_id_manager"]
+        assert manager
+        return manager
+
+    @tornado.web.authenticated
+    async def post(self):
+        chat_path = self.get_argument('chat_path', None)
+        if not chat_path:
+            raise tornado.web.HTTPError(400, "chat_path is required as a URL query parameter")
+
+        file_id = self.file_id_manager.get_id(chat_path)
+        if not file_id:
+            raise tornado.web.HTTPError(404, f"Chat not found: {chat_path}")
+        room_id = f"text:chat:{file_id}"
+
+        persona_manager: PersonaManager | None = self.serverapp.web_app.settings.get("jupyter-ai", {}).get("persona-managers", {}).get(room_id, None)
+        if not persona_manager:
+            raise tornado.web.HTTPError(404, f"Chat not initialized: {chat_path}")
+
+        restarted = []
+        for p in persona_manager.personas.values():
+            if not isinstance(p, BaseAcpPersona):
+                continue
+            await p.restart()
+            restarted.append(p.as_user().mention_name)
+
+        self.finish({"status": "restarted", "restarted": restarted})
+
+
 class PermissionHandler(APIHandler):
     """
     REST endpoint for permission decisions. The frontend POSTs the user's

--- a/jupyter_ai_acp_client/tests/test_restart.py
+++ b/jupyter_ai_acp_client/tests/test_restart.py
@@ -1,0 +1,223 @@
+"""Tests for the ACP agent subprocess restart mechanism."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+import pytest
+import tornado.web
+
+from jupyter_ai_acp_client.base_acp_persona import BaseAcpPersona
+from jupyter_ai_acp_client.routes import RestartSubprocessHandler
+
+
+class ConcretePersona(BaseAcpPersona):
+    """Concrete subclass for testing (avoids ClassVar sharing with base)."""
+
+    _before_subprocess_future = None
+    _subprocess_future = None
+    _client_future = None
+
+
+def _make_restart_persona():
+    """Create a mock persona suitable for restart tests."""
+    persona = MagicMock(spec=ConcretePersona)
+    persona.__class__ = ConcretePersona
+    persona.restart = AsyncMock()
+    user_mock = MagicMock()
+    user_mock.mention_name = "test-bot"
+    persona.as_user.return_value = user_mock
+    return persona
+
+
+class TestRestartMethod:
+    """Tests for BaseAcpPersona.restart()."""
+
+    async def test_restart_kills_subprocess_and_reinitializes(self):
+        """restart() should kill the subprocess and reset class futures."""
+        persona = MagicMock()
+        persona.__class__ = ConcretePersona
+        persona.log = MagicMock()
+        persona.event_loop = asyncio.get_event_loop()
+        persona._executable = ["echo", "test"]
+
+        # Mock subprocess
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        mock_proc.wait = AsyncMock()
+
+        # Mock client
+        mock_client = MagicMock()
+        mock_client._personas_by_session = {"sess-1": persona}
+        mock_conn = MagicMock()
+        mock_conn.close = AsyncMock()
+        mock_client.get_connection = AsyncMock(return_value=mock_conn)
+
+        persona.get_client = AsyncMock(return_value=mock_client)
+        persona.get_agent_subprocess = AsyncMock(return_value=mock_proc)
+        persona.before_agent_subprocess = AsyncMock()
+        persona._init_agent_subprocess = AsyncMock(return_value=mock_proc)
+        persona._init_client = AsyncMock(return_value=mock_client)
+        persona._init_client_session = AsyncMock()
+
+        with patch("os.getpgid", return_value=12345), patch("os.killpg") as mock_killpg:
+            await BaseAcpPersona.restart(persona)
+
+        # Verify subprocess was killed
+        mock_killpg.assert_called()
+        # Verify connection was closed
+        mock_conn.close.assert_called_once()
+
+    async def test_restart_reinitializes_sessions_for_siblings(self):
+        """restart() should re-init sessions for all personas sharing the subprocess."""
+        persona1 = MagicMock()
+        persona1.__class__ = ConcretePersona
+        persona1.log = MagicMock()
+        persona1.event_loop = asyncio.get_event_loop()
+        persona1._executable = ["echo"]
+
+        persona2 = MagicMock()
+        persona2.__class__ = ConcretePersona
+        persona2.log = MagicMock()
+        persona2.event_loop = asyncio.get_event_loop()
+
+        mock_proc = MagicMock()
+        mock_proc.pid = 100
+        mock_proc.wait = AsyncMock()
+
+        mock_client = MagicMock()
+        mock_client._personas_by_session = {"s1": persona1, "s2": persona2}
+        mock_conn = MagicMock()
+        mock_conn.close = AsyncMock()
+        mock_client.get_connection = AsyncMock(return_value=mock_conn)
+
+        persona1.get_client = AsyncMock(return_value=mock_client)
+        persona1.get_agent_subprocess = AsyncMock(return_value=mock_proc)
+        persona1.before_agent_subprocess = AsyncMock()
+        persona1._init_agent_subprocess = AsyncMock(return_value=mock_proc)
+        persona1._init_client = AsyncMock(return_value=mock_client)
+        persona1._init_client_session = AsyncMock()
+        persona2._init_client_session = AsyncMock()
+
+        with patch("os.getpgid", return_value=100), patch("os.killpg"):
+            await BaseAcpPersona.restart(persona1)
+
+        # Both personas should have their session re-initialized
+        persona1._init_client_session.assert_called_once()
+        persona2._init_client_session.assert_called_once()
+
+    async def test_restart_handles_already_dead_subprocess(self):
+        """restart() should handle ProcessLookupError gracefully."""
+        persona = MagicMock()
+        persona.__class__ = ConcretePersona
+        persona.log = MagicMock()
+        persona.event_loop = asyncio.get_event_loop()
+        persona._executable = ["echo"]
+
+        mock_proc = MagicMock()
+        mock_proc.pid = 999
+
+        mock_client = MagicMock()
+        mock_client._personas_by_session = {}
+        mock_conn = MagicMock()
+        mock_conn.close = AsyncMock()
+        mock_client.get_connection = AsyncMock(return_value=mock_conn)
+
+        persona.get_client = AsyncMock(return_value=mock_client)
+        persona.get_agent_subprocess = AsyncMock(return_value=mock_proc)
+        persona.before_agent_subprocess = AsyncMock()
+        persona._init_agent_subprocess = AsyncMock(return_value=mock_proc)
+        persona._init_client = AsyncMock(return_value=mock_client)
+        persona._init_client_session = AsyncMock()
+
+        with patch("os.getpgid", side_effect=ProcessLookupError):
+            # Should not raise
+            await BaseAcpPersona.restart(persona)
+
+        # Class futures should still be reset and re-initialized
+        assert ConcretePersona._before_subprocess_future is not None
+
+
+class TestRestartSubprocessHandler:
+    """Tests for the REST endpoint handler."""
+
+    def _make_handler(self, personas: dict):
+        """Create a mock RestartSubprocessHandler."""
+        handler = object.__new__(RestartSubprocessHandler)
+        handler.application = MagicMock()
+        handler.request = MagicMock()
+        handler.request.connection = MagicMock()
+        handler._transforms = []
+
+        serverapp = MagicMock()
+        file_id_manager = MagicMock()
+        file_id_manager.get_id.return_value = "file-id-1"
+
+        persona_manager = MagicMock()
+        persona_manager.personas = personas
+
+        serverapp.web_app.settings = {
+            "file_id_manager": file_id_manager,
+            "jupyter-ai": {
+                "persona-managers": {
+                    "text:chat:file-id-1": persona_manager,
+                },
+            },
+        }
+
+        type(handler).serverapp = PropertyMock(return_value=serverapp)
+        return handler
+
+    async def test_restart_requires_chat_path(self):
+        """POST without chat_path should return 400."""
+        handler = self._make_handler({})
+        with patch.object(handler, "get_argument", return_value=None):
+            with patch.object(handler, "get_current_user", return_value={"name": "test"}):
+                with pytest.raises(tornado.web.HTTPError) as exc_info:
+                    await handler.post()
+                assert exc_info.value.status_code == 400
+
+    async def test_restart_chat_not_found(self):
+        """POST with unknown chat_path should return 404."""
+        handler = self._make_handler({})
+        serverapp = handler.serverapp
+        serverapp.web_app.settings["file_id_manager"].get_id.return_value = None
+
+        with patch.object(handler, "get_argument", return_value="nonexistent.chat"):
+            with patch.object(handler, "get_current_user", return_value={"name": "test"}):
+                with pytest.raises(tornado.web.HTTPError) as exc_info:
+                    await handler.post()
+                assert exc_info.value.status_code == 404
+
+    async def test_restart_calls_persona_restart(self):
+        """POST should call restart() on all ACP personas in the chat."""
+        persona = _make_restart_persona()
+        handler = self._make_handler({"p1": persona})
+
+        with patch.object(handler, "get_argument", return_value="test.chat"):
+            with patch.object(handler, "get_current_user", return_value={"name": "test"}):
+                with patch.object(handler, "finish") as mock_finish:
+                    # isinstance check needs to work with our mock
+                    with patch(
+                        "jupyter_ai_acp_client.routes.isinstance",
+                        side_effect=lambda obj, cls: obj is persona if cls is BaseAcpPersona else isinstance(obj, cls),
+                    ):
+                        await handler.post()
+
+                    persona.restart.assert_called_once()
+                    mock_finish.assert_called_once()
+                    result = mock_finish.call_args[0][0]
+                    assert result["status"] == "restarted"
+                    assert "test-bot" in result["restarted"]
+
+    async def test_restart_skips_non_acp_personas(self):
+        """POST should skip personas that are not BaseAcpPersona instances."""
+        non_acp = MagicMock()
+        non_acp.__class__ = type("OtherPersona", (), {})
+        handler = self._make_handler({"p1": non_acp})
+
+        with patch.object(handler, "get_argument", return_value="test.chat"):
+            with patch.object(handler, "get_current_user", return_value={"name": "test"}):
+                with patch.object(handler, "finish") as mock_finish:
+                    await handler.post()
+                    result = mock_finish.call_args[0][0]
+                    assert result["restarted"] == []


### PR DESCRIPTION
## Summary

Add a mechanism to restart a specific ACP agent subprocess without restarting the entire Jupyter server. This addresses the need to restart an agent process per chat room (e.g., after changing configuration or when it enters a corrupted state).

## Changes

- **`BaseAcpPersona.restart()`**: New method that kills the existing subprocess, resets class-level futures, and re-initializes the subprocess, client, and sessions for all persona instances sharing that process.
- **`POST /ai/acp/restart?chat_path=<path>`**: New REST endpoint that triggers restart for all ACP personas in the given chat room.
- **`RestartSubprocessHandler`**: Registered in `extension_app.py`.
- **Tests**: Comprehensive test coverage in `test_restart.py` (7 tests covering subprocess kill + reinit, sibling session reinit, dead subprocess handling, and REST endpoint validation).

## Testing

- All 264 tests pass (including 7 new restart tests)
- mypy: no new type errors (all existing errors are pre-existing missing stubs)

Closes #78