### PR TITLE
fix(claude): gate subprocess on auth + detect Bedrock credentials

### DIFF
--- a/jupyter_ai_acp_client/acp_personas/claude.py
+++ b/jupyter_ai_acp_client/acp_personas/claude.py
@@ -1,4 +1,7 @@
+import asyncio
+import json
 import shutil
+
 from jupyter_ai_persona_manager import PersonaRequirementsUnmet
 if shutil.which("claude-agent-acp") is None:
     raise PersonaRequirementsUnmet(
@@ -32,11 +35,43 @@ def _is_auth_error(error: Exception) -> bool:
     )
 
 
+async def _check_claude_auth() -> bool:
+    """Check if Claude is authenticated via Anthropic OAuth or AWS Bedrock."""
+    # Check Anthropic OAuth via claude auth status
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "claude", "auth", "status", "--json",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10.0)
+        result = json.loads(stdout.decode())
+        if result.get("loggedIn", False):
+            return True
+    except (asyncio.TimeoutError, json.JSONDecodeError, FileNotFoundError, OSError):
+        pass
+
+    # Check AWS/Bedrock credentials via aws sts get-caller-identity
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "aws", "sts", "get-caller-identity",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        await asyncio.wait_for(proc.communicate(), timeout=10.0)
+        if proc.returncode == 0:
+            return True
+    except (asyncio.TimeoutError, FileNotFoundError, OSError):
+        pass
+
+    return False
+
+
 class ClaudeAcpPersona(BaseAcpPersona):
     def __init__(self, *args, **kwargs):
         executable = ["claude-agent-acp"]
         super().__init__(*args, executable=executable, **kwargs)
-    
+
     @property
     def defaults(self) -> PersonaDefaults:
         avatar_path = str(os.path.abspath(
@@ -49,24 +84,28 @@ class ClaudeAcpPersona(BaseAcpPersona):
             avatar_path=avatar_path,
             system_prompt="unused"
         )
-    
+
     async def before_agent_subprocess(self):
-        # The Claude ACP agent server seems to always be able to start as long
-        # as `claude-agent-acp` is installed, so this method does not need to be
-        # implemented.
-        return None
+        """Block subprocess startup until Claude is authenticated.
+        Polls both `claude auth status` (Anthropic OAuth) and
+        `aws sts get-caller-identity` (Bedrock) every 3 seconds.
+        """
+        if await _check_claude_auth():
+            return
+
+        self.log.info("[Claude] Waiting for user to authenticate...")
+        while not await _check_claude_auth():
+            await asyncio.sleep(3)
+        self.log.info("[Claude] Authentication detected, starting subprocess.")
 
     async def is_authed(self) -> bool:
-        # Unfortunately, we cannot check the exit code of `claude auth status`
-        # as documented to implement this method. This command may claim the
-        # user is authenticated even if their token is expired. So we have to
-        # always return `True` here.
-        # 
-        # Upon auth failure, the `process_message()` method raises
-        # `acp.exceptions.RequestError: Authentication required` when the user
-        # is not logged in. We use that to inform the user to log in.
+        if not self._before_subprocess_future.done():
+            return False
         return True
-    
+
+    def _needs_auth_before_subprocess(self) -> bool:
+        return True
+
     async def process_message(self, message: Message) -> None:
         try:
             await super().process_message(message)
@@ -77,11 +116,8 @@ class ClaudeAcpPersona(BaseAcpPersona):
             else:
                 raise e
 
-
     async def handle_no_auth(self, message: Message) -> None:
         await super().handle_no_auth(message)
-        # Claude supports several authentication options so we just send a
-        # canned response and let the user choose for themselves.
         self.send_message(
             "You're not authenticated with Claude."
             "\n\n- If you want to log in with a Claude.ai account, run the following in a new terminal:"

--- a/jupyter_ai_acp_client/acp_personas/gemini.py
+++ b/jupyter_ai_acp_client/acp_personas/gemini.py
@@ -121,6 +121,9 @@ class GeminiAcpPersona(BaseAcpPersona):
         # configured before processing each message. Use a fast file check.
         return await self._check_gemini_auth_fast()
 
+    def _needs_auth_before_subprocess(self) -> bool:
+        return True
+
     async def handle_no_auth(self, message: Message) -> None:
         await super().handle_no_auth(message)
 

--- a/jupyter_ai_acp_client/acp_personas/kiro.py
+++ b/jupyter_ai_acp_client/acp_personas/kiro.py
@@ -118,7 +118,10 @@ class KiroAcpPersona(BaseAcpPersona):
         # of the `before_agent_subprocess()` task to check if the user is
         # authenticated.
         return self._before_subprocess_future.done()
-    
+
+    def _needs_auth_before_subprocess(self) -> bool:
+        return True
+
     async def handle_no_auth(self, message: Message) -> None:
         await super().handle_no_auth(message)
 

--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -220,7 +220,15 @@ class BaseAcpPersona(BasePersona):
         """
         After the user signs in, send a hidden prompt with chat history so the
         agent can proactively offer to continue with the user's original request.
+
+        For agents with pre-existing sessions (e.g. Codex, Copilot), the
+        subprocess may have been started before auth. We restart it first.
         """
+        if not self._needs_auth_before_subprocess():
+            await self._restart_agent()
+            client = await self.get_client()
+            session_id = await self.get_session_id()
+
         history = self._build_history_context(
             preamble=(
                 "You just became available after the user signed in. "
@@ -244,6 +252,38 @@ class BaseAcpPersona(BasePersona):
             session_id=session_id,
             prompt=prompt,
             root_dir=self.parent.root_dir,
+        )
+
+    def _needs_auth_before_subprocess(self) -> bool:
+        """
+        Returns True if this agent blocks subprocess startup until auth passes.
+        Subclasses that gate subprocess startup on auth should override this.
+        """
+        return False
+
+    async def _restart_agent(self) -> None:
+        """
+        Kills the current ACP agent subprocess and client, then starts fresh
+        ones. Used when the subprocess was started before authentication and
+        needs to pick up new credentials after the user signs in.
+        """
+        self.log.info("[%s] Restarting agent subprocess to pick up new credentials.", self.__class__.__name__)
+
+        old_process = await self.__class__._subprocess_future
+        try:
+            old_process.terminate()
+            await asyncio.wait_for(old_process.wait(), timeout=5.0)
+        except (ProcessLookupError, asyncio.TimeoutError):
+            old_process.kill()
+
+        self.__class__._subprocess_future = self.event_loop.create_task(
+            self._init_agent_subprocess()
+        )
+        self.__class__._client_future = self.event_loop.create_task(
+            self._init_client()
+        )
+        self._client_session_future = self.event_loop.create_task(
+            self._init_client_session()
         )
 
     async def get_agent_subprocess(self) -> asyncio.subprocess.Process:


### PR DESCRIPTION
## Summary

Fix Claude's resume-after-auth to work automatically (like Kiro) by gating the subprocess on authentication. Also adds Bedrock credential detection.

Based on `main` (includes #117).

## Problem

In #117, the resume-after-auth works for Kiro but not Claude:
- Claude's subprocess starts before auth → doesn't pick up new credentials after login
- No polling to detect when user authenticates
- Bedrock (AWS IAM) auth not detected by `claude auth status`

## Fix

Make Claude follow Kiro's pattern + add Bedrock detection:

- **claude.py**: Add `_check_claude_auth()` that checks BOTH `claude auth status` (Anthropic OAuth) AND `aws sts get-caller-identity` (Bedrock). Poll in `before_agent_subprocess()` until either passes.
- **base_acp_persona.py**: Add `_restart_agent()` and `_needs_auth_before_subprocess()` for pre-existing session agents (Codex, Copilot)
- **kiro.py, gemini.py**: Override `_needs_auth_before_subprocess() → True`

## Testing

Tested in SageMaker Studio (Anthropic OAuth):
1. Send message → login prompt appears ✓
2. Run `claude auth login` → authenticate ✓
3. Chat **automatically** resumes original request ✓
4. No second message needed ✓

All 20 unit tests pass.

## Related
- Fixes Claude path from #117