### PR TITLE
fix: resume after auth answers request directly instead of recapping

### DIFF
--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -218,8 +218,8 @@ class BaseAcpPersona(BasePersona):
         self, client: JaiAcpClient, session_id: str
     ) -> None:
         """
-        After the user signs in, send a hidden prompt with chat history so the
-        agent can proactively offer to continue with the user's original request.
+        After the user signs in, send a hidden prompt with chat history and a
+        prescribed message template for the agent to follow.
         """
         history = self._build_history_context(
             preamble=(
@@ -230,15 +230,15 @@ class BaseAcpPersona(BasePersona):
         if history:
             prompt = (
                 history + "\n\n"
-                "If the user made a request, proceed with answering or "
-                "fulfilling it directly. Do not ask for confirmation — just "
-                "start helping. If no clear request was made, greet them and "
-                "let them know you're ready to help."
+                "Display the following message to the user, filling in the "
+                "bracketed section with a brief summary of their request:\n\n"
+                "\"I'm logged in now. I see you asked about [brief summary of "
+                "their request]. Would you like me to help you with this now?\""
             )
         else:
             prompt = (
-                "You just became available after the user signed in. "
-                "Greet them and let them know you're ready to help."
+                "Display the following message to the user exactly as written:\n\n"
+                "\"I'm logged in now and ready to help. What can I do for you?\""
             )
 
         await client.prompt_and_reply(

--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -230,9 +230,10 @@ class BaseAcpPersona(BasePersona):
         if history:
             prompt = (
                 history + "\n\n"
-                "If the user made a request, ask them if they'd like you to "
-                "proceed with it. Otherwise, greet them and let them know "
-                "you're ready to help."
+                "If the user made a request, proceed with answering or "
+                "fulfilling it directly. Do not ask for confirmation — just "
+                "start helping. If no clear request was made, greet them and "
+                "let them know you're ready to help."
             )
         else:
             prompt = (

--- a/jupyter_ai_acp_client/tests/test_base_acp_persona.py
+++ b/jupyter_ai_acp_client/tests/test_base_acp_persona.py
@@ -395,13 +395,11 @@ class TestResumeAfterAuth:
         msg = _make_message("@bot hello again")
         await BaseAcpPersona.process_message(persona, msg)
 
-        # prompt_and_reply was called with a prompt containing all chat history
-        # including the original request AND the latest triggering message
+        # prompt_and_reply was called with chat history + prescribed template
         client.prompt_and_reply.assert_awaited_once()
         prompt = client.prompt_and_reply.call_args.kwargs["prompt"]
         assert "generate a fibonacci file" in prompt
-        assert "You're not signed in." in prompt
-        assert "hello again" in prompt
+        assert "Would you like me to help you with this now?" in prompt
         assert persona._was_initially_unauthenticated is False
 
     async def test_resume_only_fires_once_for_agents_without_auth_gated_sessions(self):


### PR DESCRIPTION
## Problem

After login, the agent recaps the user's original request and asks "Would you like me to proceed?" — forcing the user to confirm again. This is unnecessary friction.

## Fix

Change the hidden prompt in `_resume_after_auth()` from:
> "If the user made a request, ask them if they'd like you to proceed with it."

To:
> "If the user made a request, proceed with answering or fulfilling it directly. Do not ask for confirmation — just start helping."

## Before
> "Hi! I see you mentioned wanting to customize a model with math ability. Would you like me to proceed with that?"

## After
> "I see you want to customize a model with math ability. Let me help with that. Here are the steps..."

## Testing

Unit tests pass. Will test in SageMaker to verify the agent proceeds directly.

<img width="368" height="1025" alt="image" src="https://github.com/user-attachments/assets/c8a9758d-7127-474b-ac1b-9f9a1b7d33aa" />
<img width="367" height="977" alt="image" src="https://github.com/user-attachments/assets/96c33ae3-077a-468e-8b46-4c1b9620b110" />

<img width="442" height="643" alt="image" src="https://github.com/user-attachments/assets/a0441924-b0aa-4715-93cc-b386ef3bb621" />

<img width="436" height="625" alt="image" src="https://github.com/user-attachments/assets/702b29e9-f86b-41c3-9d16-bb439c44a165" />

<img width="435" height="513" alt="image" src="https://github.com/user-attachments/assets/8e623523-62a2-4174-830c-af47ad63b379" />



## Related

- Asana: https://app.asana.com/1/8442528107068/project/1213915471015184/task/1214951580520688