### PR TITLE
Show structured error info for ACP RequestError

### DIFF
--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -413,18 +413,42 @@ class BaseAcpPersona(BasePersona):
         self._acp_slash_commands = commands
 
     async def handle_uncaught_exception(self, exc: Exception) -> None:
-        """Show structured error info for ACP RequestError instead of raw tracebacks."""
+        """Show structured error info for ACP RequestError inside the standard dropdown."""
         if not isinstance(exc, RequestError):
             await super().handle_uncaught_exception(exc)
             return
 
-        parts = [f"**Error {exc.code}**: {html.escape(str(exc))}"]
-        if exc.data is not None:
-            parts.append(f"\n\n**Details**: `{html.escape(str(exc.data))}`")
+        import json
+        import traceback
 
-        self.send_message(
-            "An error occurred while processing your message.\n\n" + "".join(parts)
+        tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+        error_msg = str(exc)
+        if len(error_msg) > 120:
+            error_msg = error_msg[:120] + "…"
+        summary = f"Error {exc.code}: {html.escape(error_msg)}"
+
+        # Build inner content
+        sections = [f"**Error code:** {exc.code}\n\n**Message:** {html.escape(str(exc))}"]
+
+        if exc.data is not None:
+            try:
+                data_str = json.dumps(exc.data, indent=2)
+            except (TypeError, ValueError):
+                data_str = str(exc.data)
+            sections.append(f"**Data:**\n\n```json\n{data_str}\n```")
+
+        sections.append(f"**Traceback:**\n\n```\n{tb}```")
+
+        inner = "\n\n".join(sections)
+
+        body = (
+            f"An error occurred while processing your message.\n\n"
+            f'<details class="jp-jai-error-details">\n'
+            f"<summary>Error details ({summary})</summary>\n\n"
+            f"{inner}\n"
+            f"</details>"
         )
+        self.send_message(body)
 
     async def shutdown(self):
         if getattr(self, "_shutting_down", False):

--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -1,4 +1,5 @@
 import asyncio
+import html
 import os
 import signal
 import sys
@@ -7,6 +8,7 @@ from asyncio.subprocess import Process
 from typing import Any, ClassVar, Optional
 
 from acp import NewSessionResponse, LoadSessionResponse
+from acp.exceptions import RequestError
 from acp.schema import AvailableCommand
 from jupyter_ai_persona_manager import BasePersona
 from jupyterlab_chat.models import Message
@@ -409,6 +411,20 @@ class BaseAcpPersona(BasePersona):
             self.parent.room_id,
         )
         self._acp_slash_commands = commands
+
+    async def handle_uncaught_exception(self, exc: Exception) -> None:
+        """Show structured error info for ACP RequestError instead of raw tracebacks."""
+        if not isinstance(exc, RequestError):
+            await super().handle_uncaught_exception(exc)
+            return
+
+        parts = [f"**Error {exc.code}**: {html.escape(str(exc))}"]
+        if exc.data is not None:
+            parts.append(f"\n\n**Details**: `{html.escape(str(exc.data))}`")
+
+        self.send_message(
+            "An error occurred while processing your message.\n\n" + "".join(parts)
+        )
 
     async def shutdown(self):
         if getattr(self, "_shutting_down", False):

--- a/jupyter_ai_acp_client/tests/test_base_acp_persona.py
+++ b/jupyter_ai_acp_client/tests/test_base_acp_persona.py
@@ -460,7 +460,8 @@ class TestHandleUncaughtException:
         await BaseAcpPersona.handle_uncaught_exception(persona, exc)
 
         body = persona.send_message.call_args[0][0]
-        assert "**Error -32603**" in body
+        assert "jp-jai-error-details" in body
+        assert "Error -32603" in body
         assert "Internal error" in body
 
     async def test_request_error_shows_data(self):
@@ -473,7 +474,7 @@ class TestHandleUncaughtException:
         await BaseAcpPersona.handle_uncaught_exception(persona, exc)
 
         body = persona.send_message.call_args[0][0]
-        assert "**Details**" in body
+        assert "```json" in body
         assert "/tmp/x" in body
 
     async def test_request_error_without_data(self):
@@ -486,8 +487,9 @@ class TestHandleUncaughtException:
         await BaseAcpPersona.handle_uncaught_exception(persona, exc)
 
         body = persona.send_message.call_args[0][0]
-        assert "**Error -32000**" in body
-        assert "**Details**" not in body
+        assert "Error -32000" in body
+        assert "```json" not in body
+        assert "**Traceback:**" in body
 
     async def test_non_request_error_delegates_to_super(self):
         """Non-RequestError exceptions should not use the structured format."""
@@ -495,19 +497,11 @@ class TestHandleUncaughtException:
         persona.send_message = MagicMock()
 
         exc = RuntimeError("something broke")
-        # super().handle_uncaught_exception() calls send_message with a
-        # <details> element containing the traceback. Since we can't easily
-        # call super() with a MagicMock, just verify that our method does NOT
-        # produce the structured "Error <code>" format for non-RequestError.
-        # We need a real-ish persona for super() to work, so just verify the
-        # isinstance check by confirming send_message is NOT called with our format.
         try:
             await BaseAcpPersona.handle_uncaught_exception(persona, exc)
         except TypeError:
-            # super() fails with MagicMock — that's expected and proves we
-            # attempted to delegate to the parent class.
+            # super() fails with MagicMock — proves we delegated
             pass
-        # Confirm our structured format was NOT used
         if persona.send_message.called:
             body = persona.send_message.call_args[0][0]
-            assert "**Error" not in body
+            assert "**Error code:**" not in body

--- a/jupyter_ai_acp_client/tests/test_base_acp_persona.py
+++ b/jupyter_ai_acp_client/tests/test_base_acp_persona.py
@@ -445,3 +445,69 @@ class TestResumeAfterAuth:
         await BaseAcpPersona._init_client_session(persona)
 
         persona._resume_after_auth.assert_not_awaited()
+
+
+class TestHandleUncaughtException:
+    """Tests for structured RequestError display in handle_uncaught_exception."""
+
+    async def test_request_error_shows_code_and_message(self):
+        from acp.exceptions import RequestError
+
+        persona = MagicMock()
+        persona.send_message = MagicMock()
+
+        exc = RequestError(-32603, "Internal error")
+        await BaseAcpPersona.handle_uncaught_exception(persona, exc)
+
+        body = persona.send_message.call_args[0][0]
+        assert "**Error -32603**" in body
+        assert "Internal error" in body
+
+    async def test_request_error_shows_data(self):
+        from acp.exceptions import RequestError
+
+        persona = MagicMock()
+        persona.send_message = MagicMock()
+
+        exc = RequestError(-32603, "Internal error", {"path": "/tmp/x"})
+        await BaseAcpPersona.handle_uncaught_exception(persona, exc)
+
+        body = persona.send_message.call_args[0][0]
+        assert "**Details**" in body
+        assert "/tmp/x" in body
+
+    async def test_request_error_without_data(self):
+        from acp.exceptions import RequestError
+
+        persona = MagicMock()
+        persona.send_message = MagicMock()
+
+        exc = RequestError(-32000, "Authentication required")
+        await BaseAcpPersona.handle_uncaught_exception(persona, exc)
+
+        body = persona.send_message.call_args[0][0]
+        assert "**Error -32000**" in body
+        assert "**Details**" not in body
+
+    async def test_non_request_error_delegates_to_super(self):
+        """Non-RequestError exceptions should not use the structured format."""
+        persona = MagicMock()
+        persona.send_message = MagicMock()
+
+        exc = RuntimeError("something broke")
+        # super().handle_uncaught_exception() calls send_message with a
+        # <details> element containing the traceback. Since we can't easily
+        # call super() with a MagicMock, just verify that our method does NOT
+        # produce the structured "Error <code>" format for non-RequestError.
+        # We need a real-ish persona for super() to work, so just verify the
+        # isinstance check by confirming send_message is NOT called with our format.
+        try:
+            await BaseAcpPersona.handle_uncaught_exception(persona, exc)
+        except TypeError:
+            # super() fails with MagicMock — that's expected and proves we
+            # attempted to delegate to the parent class.
+            pass
+        # Confirm our structured format was NOT used
+        if persona.send_message.called:
+            body = persona.send_message.call_args[0][0]
+            assert "**Error" not in body


### PR DESCRIPTION
## Summary

When `acp.exceptions.RequestError` propagates uncaught from `process_message()`, the chat UI previously showed a generic `RequestError: <message>` summary with only the raw traceback inside the dropdown.

This PR overrides `handle_uncaught_exception` in `BaseAcpPersona` to show structured error information inside the same dropdown UI (red X, `jp-jai-error-details` class):

1. **Error code & message** (e.g. `-32603: Internal error`)
2. **Error data** as a JSON code block (when present)
3. **Traceback** in a code block

Non-`RequestError` exceptions delegate to the parent class unchanged.

## Changes

- `base_acp_persona.py`: Added `handle_uncaught_exception` override
- `tests/test_base_acp_persona.py`: Added 4 tests

## Testing

- All 261 tests pass

## Screenshot

<img width="503" height="765" alt="Screenshot 2026-05-19 at 4 37 32 PM" src="https://github.com/user-attachments/assets/ff6d6fb8-a52f-4205-bf1f-616eeede9fd9" />
