### PR TITLE
Show context, token, and cost usage for the active persona in the chat input

### DIFF
--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -103,16 +103,21 @@ class BaseAcpPersona(BasePersona):
 
     _acp_context_usage: Optional[UsageUpdate]
     """
-    The latest `usage_update` from the ACP agent: tokens currently in context,
-    context window size, and optional cumulative session cost. `None` until the
-    agent sends one; some agents never do. Set by the default ACP client.
+    How full the agent's context window is right now: tokens currently in
+    context, window size, and optional cumulative session cost, from the
+    latest `usage_update`. A live snapshot that can decrease (e.g. after
+    compaction). Distinct from `acp_session_usage`, which counts total
+    session throughput. `None` until the agent sends one; some agents
+    never do. Set by the default ACP client.
     """
 
     _acp_session_usage: Optional[Usage]
     """
-    Cumulative session token usage from the latest prompt response. All values
-    are totals across the session, not per turn. `None` until a prompt response
-    carries usage. Set by the default ACP client.
+    Cumulative token totals for the whole session from the latest prompt
+    response: never decreases, and includes cache re-reads, so it grows
+    past the context window size. Distinct from `acp_context_usage`, which measures
+    current window occupancy. `None` until a prompt response carries
+    usage. Set by the default ACP client.
     """
 
     _MAX_HISTORY_MESSAGES: ClassVar[int] = 50
@@ -682,26 +687,31 @@ class BaseAcpPersona(BasePersona):
     @property
     def acp_context_usage(self) -> Optional[UsageUpdate]:
         """
-        The latest context usage reported by the ACP agent: tokens currently in
-        context, window size, and optional cumulative session cost. `None` when
-        the agent has not reported any.
+        How full the agent's context window is right now: tokens currently in
+        context, window size, and optional cumulative session cost, from the
+        latest `usage_update`. A live snapshot that can decrease (e.g. after
+        compaction). Distinct from `acp_session_usage`, which counts total
+        session throughput. `None` when the agent has not reported any.
         """
         return self._acp_context_usage
 
-    def _set_acp_context_usage(self, usage: UsageUpdate) -> None:
-        """Store a `usage_update` received from the ACP agent."""
+    def update_acp_context_usage(self, usage: UsageUpdate) -> None:
+        """Record a `usage_update` received from the ACP agent."""
         self._acp_context_usage = usage
 
     @property
     def acp_session_usage(self) -> Optional[Usage]:
         """
-        Cumulative session token usage from the latest prompt response. `None`
-        when no prompt response has carried usage.
+        Cumulative token totals for the whole session from the latest prompt
+        response: never decreases, and includes cache re-reads, so it grows
+        past the context window size. Distinct from `acp_context_usage`, which measures
+        current window occupancy. `None` when no prompt response has carried
+        usage.
         """
         return self._acp_session_usage
 
-    def _set_acp_session_usage(self, usage: Usage) -> None:
-        """Store the token usage carried on a completed prompt response."""
+    def update_acp_session_usage(self, usage: Usage) -> None:
+        """Record the token usage carried on a completed prompt response."""
         self._acp_session_usage = usage
 
     async def handle_uncaught_exception(self, exc: Exception) -> None:

--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -241,7 +241,7 @@ class BaseAcpPersona(BasePersona):
         )
         self._set_acp_model_state(response.models)
         self._set_acp_mode_state(response.modes)
-        self._set_acp_config_options(response.config_options)
+        self.update_acp_config_options(response.config_options)
         return response
 
     @auto_emit_event("acp_session_init", lambda self: {"session_operation": "new"})
@@ -255,7 +255,7 @@ class BaseAcpPersona(BasePersona):
         self._record_new_session(response.session_id)
         self._set_acp_model_state(response.models)
         self._set_acp_mode_state(response.modes)
-        self._set_acp_config_options(response.config_options)
+        self.update_acp_config_options(response.config_options)
 
         # Reapply a previously selected model so the choice survives session
         # recreation (e.g. a server restart that creates a fresh ACP session).
@@ -615,7 +615,7 @@ class BaseAcpPersona(BasePersona):
         self._acp_modes = modes.available_modes
         self._acp_current_mode_id = modes.current_mode_id
 
-    def _set_acp_current_mode(self, mode_id: str) -> None:
+    def update_acp_current_mode(self, mode_id: str) -> None:
         """Record a mode the agent switched to itself (a `current_mode_update`)."""
         self._acp_current_mode_id = mode_id
 
@@ -648,7 +648,7 @@ class BaseAcpPersona(BasePersona):
         """
         return self._acp_config_options
 
-    def _set_acp_config_options(
+    def update_acp_config_options(
         self, config_options: Optional[list[AcpConfigOption]]
     ) -> None:
         """

--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -17,6 +17,8 @@ from acp.schema import (
     SessionMode,
     SessionModelState,
     SessionModeState,
+    Usage,
+    UsageUpdate,
 )
 from jupyter_ai_persona_manager import BasePersona
 from jupyterlab_chat.models import Message
@@ -99,6 +101,20 @@ class BaseAcpPersona(BasePersona):
     when a session is created or loaded.
     """
 
+    _acp_context_usage: Optional[UsageUpdate]
+    """
+    The latest `usage_update` from the ACP agent: tokens currently in context,
+    context window size, and optional cumulative session cost. `None` until the
+    agent sends one; some agents never do. Set by the default ACP client.
+    """
+
+    _acp_session_usage: Optional[Usage]
+    """
+    Cumulative session token usage from the latest prompt response. All values
+    are totals across the session, not per turn. `None` until a prompt response
+    carries usage. Set by the default ACP client.
+    """
+
     _MAX_HISTORY_MESSAGES: ClassVar[int] = 50
     """
     Maximum number of recent messages to include in the history context injected
@@ -146,6 +162,8 @@ class BaseAcpPersona(BasePersona):
         self._acp_modes = []
         self._acp_current_mode_id = None
         self._acp_config_options = []
+        self._acp_context_usage = None
+        self._acp_session_usage = None
 
     async def before_agent_subprocess(self) -> None:
         """
@@ -660,6 +678,31 @@ class BaseAcpPersona(BasePersona):
     def _get_stored_config_choices(self) -> dict[str, str | bool]:
         """Return config option values previously selected for this persona here."""
         return self.ychat.get_metadata().get("acp_config_options", {}).get(self.id, {})
+
+    @property
+    def acp_context_usage(self) -> Optional[UsageUpdate]:
+        """
+        The latest context usage reported by the ACP agent: tokens currently in
+        context, window size, and optional cumulative session cost. `None` when
+        the agent has not reported any.
+        """
+        return self._acp_context_usage
+
+    def _set_acp_context_usage(self, usage: UsageUpdate) -> None:
+        """Store a `usage_update` received from the ACP agent."""
+        self._acp_context_usage = usage
+
+    @property
+    def acp_session_usage(self) -> Optional[Usage]:
+        """
+        Cumulative session token usage from the latest prompt response. `None`
+        when no prompt response has carried usage.
+        """
+        return self._acp_session_usage
+
+    def _set_acp_session_usage(self, usage: Usage) -> None:
+        """Store the token usage carried on a completed prompt response."""
+        self._acp_session_usage = usage
 
     async def handle_uncaught_exception(self, exc: Exception) -> None:
         """Show structured error info for ACP RequestError inside the standard dropdown."""

--- a/jupyter_ai_acp_client/default_acp_client.py
+++ b/jupyter_ai_acp_client/default_acp_client.py
@@ -334,7 +334,7 @@ class JaiAcpClient(Client):
                 # Store the cumulative session token usage when the agent
                 # reports it on the response.
                 if response.usage is not None:
-                    persona._set_acp_session_usage(response.usage)
+                    persona.update_acp_session_usage(response.usage)
 
                 # If cancelled, message already finalized by stop_streaming()
                 if self._cancel_requested.get(session_id, False):
@@ -442,7 +442,7 @@ class JaiAcpClient(Client):
         # full the agent's context window is.
         if isinstance(update, UsageUpdate):
             if persona is not None:
-                persona._set_acp_context_usage(update)
+                persona.update_acp_context_usage(update)
             return
 
         # Skip message/tool events when cancellation has been requested

--- a/jupyter_ai_acp_client/default_acp_client.py
+++ b/jupyter_ai_acp_client/default_acp_client.py
@@ -44,6 +44,7 @@ from acp.schema import (
     ToolCall,
     ToolCallProgress,
     ToolCallStart,
+    UsageUpdate,
     UserMessageChunk,
     WaitForTerminalExitResponse,
     WriteTextFileResponse,
@@ -330,6 +331,11 @@ class JaiAcpClient(Client):
                     session_id=session_id,
                 )
 
+                # Store the cumulative session token usage when the agent
+                # reports it on the response.
+                if response.usage is not None:
+                    persona._set_acp_session_usage(response.usage)
+
                 # If cancelled, message already finalized by stop_streaming()
                 if self._cancel_requested.get(session_id, False):
                     return response
@@ -395,7 +401,8 @@ class JaiAcpClient(Client):
         | AgentPlanUpdate
         | AvailableCommandsUpdate
         | CurrentModeUpdate
-        | ConfigOptionUpdate,
+        | ConfigOptionUpdate
+        | UsageUpdate,
         **kwargs: Any,
     ) -> None:
         """
@@ -429,6 +436,13 @@ class JaiAcpClient(Client):
         if isinstance(update, ConfigOptionUpdate):
             if persona is not None:
                 persona._set_acp_config_options(update.config_options)
+            return
+
+        # Keep the persona's context usage current so the toolbar can show how
+        # full the agent's context window is.
+        if isinstance(update, UsageUpdate):
+            if persona is not None:
+                persona._set_acp_context_usage(update)
             return
 
         # Skip message/tool events when cancellation has been requested

--- a/jupyter_ai_acp_client/default_acp_client.py
+++ b/jupyter_ai_acp_client/default_acp_client.py
@@ -430,12 +430,12 @@ class JaiAcpClient(Client):
         # controls reflect the current values.
         if isinstance(update, CurrentModeUpdate):
             if persona is not None:
-                persona._set_acp_current_mode(update.current_mode_id)
+                persona.update_acp_current_mode(update.current_mode_id)
             return
 
         if isinstance(update, ConfigOptionUpdate):
             if persona is not None:
-                persona._set_acp_config_options(update.config_options)
+                persona.update_acp_config_options(update.config_options)
             return
 
         # Keep the persona's context usage current so the toolbar can show how

--- a/jupyter_ai_acp_client/routes.py
+++ b/jupyter_ai_acp_client/routes.py
@@ -217,6 +217,58 @@ class ActivePersonaInfo(BaseModel):
     is_acp: bool
     avatar_url: str | None = None
 
+class AcpContextUsage(BaseModel):
+    # Tokens currently in the agent's context window.
+    used: int
+    # Total context window size in tokens.
+    size: int
+
+class AcpTokenUsage(BaseModel):
+    # All values are cumulative across the session, not per turn.
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    cached_read_tokens: int | None = None
+    cached_write_tokens: int | None = None
+    thought_tokens: int | None = None
+
+class AcpCostUsage(BaseModel):
+    # Cumulative session cost, as reported by the agent.
+    amount: float
+    currency: str
+
+class AcpUsage(BaseModel):
+    # Each field is None when the agent has not reported that quantity.
+    context: AcpContextUsage | None = None
+    tokens: AcpTokenUsage | None = None
+    cost: AcpCostUsage | None = None
+
+def build_usage(persona: BaseAcpPersona) -> AcpUsage:
+    """
+    Collect the persona's reported usage: context fill and cost from the latest
+    `usage_update`, cumulative session tokens from the latest prompt response.
+    Fields the agent has not reported stay None.
+    """
+    usage = AcpUsage()
+    context = persona.acp_context_usage
+    if context is not None:
+        usage.context = AcpContextUsage(used=context.used, size=context.size)
+        if context.cost is not None:
+            usage.cost = AcpCostUsage(
+                amount=context.cost.amount, currency=context.cost.currency
+            )
+    tokens = persona.acp_session_usage
+    if tokens is not None:
+        usage.tokens = AcpTokenUsage(
+            input_tokens=tokens.input_tokens,
+            output_tokens=tokens.output_tokens,
+            total_tokens=tokens.total_tokens,
+            cached_read_tokens=tokens.cached_read_tokens,
+            cached_write_tokens=tokens.cached_write_tokens,
+            thought_tokens=tokens.thought_tokens,
+        )
+    return usage
+
 class ActivePersonaResponse(BaseModel):
     # Every persona in the chat, for the selector.
     personas: list[ActivePersonaInfo] = []
@@ -226,6 +278,9 @@ class ActivePersonaResponse(BaseModel):
     # The active persona's session controls (model, mode, config options),
     # normalized for the input toolbar, when it is an ACP persona.
     controls: list[AcpControl] = []
+    # The active persona's reported usage (context fill, session tokens, cost),
+    # when it is an ACP persona. Quantities the agent has not reported are None.
+    usage: AcpUsage = AcpUsage()
 
 class ActivePersonaHandler(_ChatScopedHandler):
     """
@@ -249,13 +304,16 @@ class ActivePersonaHandler(_ChatScopedHandler):
         ]
         active = persona_manager.active_persona
         controls: list[AcpControl] = []
+        usage = AcpUsage()
         if isinstance(active, BaseAcpPersona):
             controls = build_controls(active)
+            usage = build_usage(active)
         response = ActivePersonaResponse(
             personas=personas,
             active_id=active.id if active else None,
             active_name=active.name if active else None,
             controls=controls,
+            usage=usage,
         )
         self.finish(response.model_dump())
 

--- a/jupyter_ai_acp_client/tests/test_default_acp_client.py
+++ b/jupyter_ai_acp_client/tests/test_default_acp_client.py
@@ -6,7 +6,12 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from acp.exceptions import RequestError
-from acp.schema import ResourceContentBlock, TextContentBlock
+from acp.schema import (
+    ResourceContentBlock,
+    TextContentBlock,
+    Usage,
+    UsageUpdate,
+)
 
 from jupyter_ai_acp_client.default_acp_client import JaiAcpClient
 
@@ -216,6 +221,48 @@ class TestPromptAndReplyContentBlocks:
 
         blocks = conn.prompt.call_args.kwargs["prompt"]
         assert blocks[1].uri == "../../../etc/passwd"
+
+
+class TestUsageStorage:
+    """A usage report received by the client ends up readable on the persona."""
+
+    async def test_usage_update_is_stored_as_context_usage(self):
+        client, _, persona = _make_client_and_persona()
+        client._loading_sessions = {}
+        persona.acp_context_usage = None
+        persona._set_acp_context_usage = lambda u: setattr(
+            persona, "acp_context_usage", u
+        )
+        update = UsageUpdate(sessionUpdate="usage_update", used=41_000, size=200_000)
+
+        await client.session_update(SESSION_ID, update)
+
+        assert persona.acp_context_usage is update
+
+    async def test_prompt_response_usage_is_stored_as_session_usage(self):
+        client, conn, persona = _make_client_and_persona()
+        usage = Usage(inputTokens=900, outputTokens=340, totalTokens=1_240)
+        conn.prompt = AsyncMock(return_value=MagicMock(usage=usage))
+        persona.acp_session_usage = None
+        persona._set_acp_session_usage = lambda u: setattr(
+            persona, "acp_session_usage", u
+        )
+
+        await client.prompt_and_reply(session_id=SESSION_ID, prompt="hello")
+
+        assert persona.acp_session_usage is usage
+
+    async def test_prompt_response_without_usage_stores_nothing(self):
+        client, conn, persona = _make_client_and_persona()
+        conn.prompt = AsyncMock(return_value=MagicMock(usage=None))
+        persona.acp_session_usage = None
+        persona._set_acp_session_usage = lambda u: setattr(
+            persona, "acp_session_usage", u
+        )
+
+        await client.prompt_and_reply(session_id=SESSION_ID, prompt="hello")
+
+        assert persona.acp_session_usage is None
 
 
 class TestLoadSessionCleanup:

--- a/jupyter_ai_acp_client/tests/test_default_acp_client.py
+++ b/jupyter_ai_acp_client/tests/test_default_acp_client.py
@@ -1,6 +1,7 @@
 """Tests for content block building and session management in JaiAcpClient."""
 
 import asyncio
+import logging
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -13,6 +14,7 @@ from acp.schema import (
     UsageUpdate,
 )
 
+from jupyter_ai_acp_client.base_acp_persona import BaseAcpPersona
 from jupyter_ai_acp_client.default_acp_client import JaiAcpClient
 
 
@@ -229,9 +231,6 @@ def _real_usage_persona():
     carrying the real usage setters and properties so tests cover the actual
     store-then-read round trip. Collaborators the client touches are mocked.
     """
-    import logging
-
-    from jupyter_ai_acp_client.base_acp_persona import BaseAcpPersona
 
     class _ConcreteAcpPersona(BaseAcpPersona):
         @property

--- a/jupyter_ai_acp_client/tests/test_default_acp_client.py
+++ b/jupyter_ai_acp_client/tests/test_default_acp_client.py
@@ -223,16 +223,38 @@ class TestPromptAndReplyContentBlocks:
         assert blocks[1].uri == "../../../etc/passwd"
 
 
+def _real_usage_persona():
+    """
+    A `BaseAcpPersona` created without `__init__` (no subprocess or session),
+    carrying the real usage setters and properties so tests cover the actual
+    store-then-read round trip. Collaborators the client touches are mocked.
+    """
+    import logging
+
+    from jupyter_ai_acp_client.base_acp_persona import BaseAcpPersona
+
+    class _ConcreteAcpPersona(BaseAcpPersona):
+        @property
+        def defaults(self):  # pragma: no cover - never called in these tests
+            return None
+
+    persona = _ConcreteAcpPersona.__new__(_ConcreteAcpPersona)
+    persona._acp_context_usage = None
+    persona._acp_session_usage = None
+    persona.log = logging.getLogger("test")
+    persona.awareness = MagicMock()
+    persona.ychat = MagicMock()
+    return persona
+
+
 class TestUsageStorage:
     """A usage report received by the client ends up readable on the persona."""
 
     async def test_usage_update_is_stored_as_context_usage(self):
-        client, _, persona = _make_client_and_persona()
+        client, _, _ = _make_client_and_persona()
         client._loading_sessions = {}
-        persona.acp_context_usage = None
-        persona._set_acp_context_usage = lambda u: setattr(
-            persona, "acp_context_usage", u
-        )
+        persona = _real_usage_persona()
+        client._personas_by_session[SESSION_ID] = persona
         update = UsageUpdate(sessionUpdate="usage_update", used=41_000, size=200_000)
 
         await client.session_update(SESSION_ID, update)
@@ -240,25 +262,21 @@ class TestUsageStorage:
         assert persona.acp_context_usage is update
 
     async def test_prompt_response_usage_is_stored_as_session_usage(self):
-        client, conn, persona = _make_client_and_persona()
+        client, conn, _ = _make_client_and_persona()
+        persona = _real_usage_persona()
+        client._personas_by_session[SESSION_ID] = persona
         usage = Usage(inputTokens=900, outputTokens=340, totalTokens=1_240)
         conn.prompt = AsyncMock(return_value=MagicMock(usage=usage))
-        persona.acp_session_usage = None
-        persona._set_acp_session_usage = lambda u: setattr(
-            persona, "acp_session_usage", u
-        )
 
         await client.prompt_and_reply(session_id=SESSION_ID, prompt="hello")
 
         assert persona.acp_session_usage is usage
 
     async def test_prompt_response_without_usage_stores_nothing(self):
-        client, conn, persona = _make_client_and_persona()
+        client, conn, _ = _make_client_and_persona()
+        persona = _real_usage_persona()
+        client._personas_by_session[SESSION_ID] = persona
         conn.prompt = AsyncMock(return_value=MagicMock(usage=None))
-        persona.acp_session_usage = None
-        persona._set_acp_session_usage = lambda u: setattr(
-            persona, "acp_session_usage", u
-        )
 
         await client.prompt_and_reply(session_id=SESSION_ID, prompt="hello")
 

--- a/jupyter_ai_acp_client/tests/test_routes.py
+++ b/jupyter_ai_acp_client/tests/test_routes.py
@@ -6,11 +6,14 @@ from unittest.mock import MagicMock, PropertyMock, patch
 import pytest
 import tornado.web
 from acp.schema import (
+    Cost,
     ModelInfo,
     SessionConfigOptionBoolean,
     SessionConfigOptionSelect,
     SessionConfigSelectOption,
     SessionMode,
+    Usage,
+    UsageUpdate,
 )
 from tornado.httpclient import HTTPClientError
 
@@ -19,6 +22,7 @@ from jupyter_ai_acp_client.routes import (
     MODEL_CONTROL_ID,
     AcpSlashCommandsHandler,
     build_controls,
+    build_usage,
 )
 
 
@@ -198,3 +202,60 @@ class TestBuildControls:
 
     def test_persona_with_nothing_advertised_yields_no_controls(self):
         assert build_controls(_persona()) == []
+
+
+def _usage_persona(*, context=None, tokens=None):
+    """A stand-in exposing only the attributes build_usage reads."""
+    return SimpleNamespace(acp_context_usage=context, acp_session_usage=tokens)
+
+
+class TestBuildUsage:
+    """Collection of a persona's reported usage into the endpoint shape."""
+
+    def test_nothing_reported_yields_all_none(self):
+        usage = build_usage(_usage_persona())
+        assert usage.context is None
+        assert usage.tokens is None
+        assert usage.cost is None
+
+    def test_context_without_cost(self):
+        update = UsageUpdate(sessionUpdate="usage_update", used=41_000, size=200_000)
+
+        usage = build_usage(_usage_persona(context=update))
+
+        assert usage.context.used == 41_000
+        assert usage.context.size == 200_000
+        assert usage.cost is None
+        assert usage.tokens is None
+
+    def test_context_with_cost(self):
+        update = UsageUpdate(
+            sessionUpdate="usage_update",
+            used=41_000,
+            size=200_000,
+            cost=Cost(amount=0.41, currency="USD"),
+        )
+
+        usage = build_usage(_usage_persona(context=update))
+
+        assert usage.cost.amount == 0.41
+        assert usage.cost.currency == "USD"
+
+    def test_session_tokens_with_optional_fields_passed_through(self):
+        tokens = Usage(
+            inputTokens=900,
+            outputTokens=340,
+            totalTokens=1_240,
+            cachedReadTokens=100,
+            thoughtTokens=50,
+        )
+
+        usage = build_usage(_usage_persona(tokens=tokens))
+
+        assert usage.tokens.input_tokens == 900
+        assert usage.tokens.output_tokens == 340
+        assert usage.tokens.total_tokens == 1_240
+        assert usage.tokens.cached_read_tokens == 100
+        assert usage.tokens.cached_write_tokens is None
+        assert usage.tokens.thought_tokens == 50
+        assert usage.context is None

--- a/src/__tests__/usage-format.spec.ts
+++ b/src/__tests__/usage-format.spec.ts
@@ -1,0 +1,37 @@
+/**
+ * Tests for the usage chip's number formatters.
+ */
+
+import { formatCost, formatTokens } from '../persona-controls';
+
+describe('formatTokens', () => {
+  it('keeps small counts as-is', () => {
+    expect(formatTokens(950)).toEqual('950');
+  });
+
+  it('formats thousands with a lowercase k', () => {
+    expect(formatTokens(41500)).toEqual('41.5k');
+  });
+
+  it('rounds up to the next tier at the boundary instead of exponential form', () => {
+    expect(formatTokens(999500)).toEqual('1M');
+  });
+
+  it('formats millions', () => {
+    expect(formatTokens(1240000)).toEqual('1.24M');
+  });
+
+  it('formats billions', () => {
+    expect(formatTokens(2500000000)).toEqual('2.5B');
+  });
+});
+
+describe('formatCost', () => {
+  it('renders USD with a dollar sign', () => {
+    expect(formatCost(0.41, 'USD')).toEqual('$0.41');
+  });
+
+  it('renders other currencies with their code', () => {
+    expect(formatCost(1.5, 'EUR')).toEqual('1.50 EUR');
+  });
+});

--- a/src/__tests__/usage-format.spec.ts
+++ b/src/__tests__/usage-format.spec.ts
@@ -2,7 +2,11 @@
  * Tests for the usage chip's number formatters.
  */
 
-import { formatCost, formatTokens } from '../persona-controls';
+import {
+  formatCost,
+  formatTokens,
+  formatTokensExact
+} from '../persona-controls';
 
 describe('formatTokens', () => {
   it('keeps small counts as-is', () => {
@@ -26,9 +30,19 @@ describe('formatTokens', () => {
   });
 });
 
+describe('formatTokensExact', () => {
+  it('renders the full count with separators for hover titles', () => {
+    expect(formatTokensExact(12456789)).toEqual('12,456,789 tokens');
+  });
+});
+
 describe('formatCost', () => {
   it('renders USD with a dollar sign', () => {
     expect(formatCost(0.41, 'USD')).toEqual('$0.41');
+  });
+
+  it('groups thousands', () => {
+    expect(formatCost(1234.5, 'USD')).toEqual('$1,234.50');
   });
 
   it('renders other currencies with their code', () => {

--- a/src/persona-controls.tsx
+++ b/src/persona-controls.tsx
@@ -394,6 +394,9 @@ function ControlsRow(props: {
   );
 }
 
+// Both formatters pin the `en` locale so exact and compact numbers agree with
+// each other and with the surrounding English labels.
+const exactNumber = new Intl.NumberFormat('en');
 const compactNumber = new Intl.NumberFormat('en', {
   notation: 'compact',
   maximumSignificantDigits: 3
@@ -513,8 +516,8 @@ function UsageChip(props: { usage: AcpUsage }): JSX.Element | null {
 
   const summary = [
     context &&
-      `Context: ${context.used.toLocaleString()} of ${formatTokens(context.size)} tokens (${percent}%)`,
-    tokens && `Session tokens: ${tokens.total_tokens.toLocaleString()}`,
+      `Context: ${exactNumber.format(context.used)} of ${formatTokens(context.size)} tokens (${percent}%)`,
+    tokens && `Session tokens: ${exactNumber.format(tokens.total_tokens)}`,
     cost && `Cost: ${formatCost(cost.amount, cost.currency)}`
   ]
     .filter(Boolean)
@@ -527,7 +530,7 @@ function UsageChip(props: { usage: AcpUsage }): JSX.Element | null {
         className={`${USAGE_CLASS}-chip ${USAGE_CLASS}-${level}`}
         onClick={event => setAnchor(event.currentTarget)}
         title={summary}
-        aria-label="Usage"
+        aria-label={context ? `Context ${percent}% used` : 'Usage'}
       >
         {context ? (
           <>
@@ -551,39 +554,39 @@ function UsageChip(props: { usage: AcpUsage }): JSX.Element | null {
           {context ? (
             <UsageSection
               label="Context"
-              value={`${context.used.toLocaleString()} of ${formatTokens(context.size)} (${percent}%)`}
+              value={`${exactNumber.format(context.used)} of ${formatTokens(context.size)} (${percent}%)`}
             />
           ) : null}
           {tokens ? (
             <>
               <UsageSection
                 label="Session tokens"
-                value={tokens.total_tokens.toLocaleString()}
+                value={exactNumber.format(tokens.total_tokens)}
               />
               <UsageRow
                 label="Input"
-                value={tokens.input_tokens.toLocaleString()}
+                value={exactNumber.format(tokens.input_tokens)}
               />
               <UsageRow
                 label="Output"
-                value={tokens.output_tokens.toLocaleString()}
+                value={exactNumber.format(tokens.output_tokens)}
               />
               {tokens.cached_read_tokens !== null ? (
                 <UsageRow
                   label="Cache read"
-                  value={tokens.cached_read_tokens.toLocaleString()}
+                  value={exactNumber.format(tokens.cached_read_tokens)}
                 />
               ) : null}
               {tokens.cached_write_tokens !== null ? (
                 <UsageRow
                   label="Cache write"
-                  value={tokens.cached_write_tokens.toLocaleString()}
+                  value={exactNumber.format(tokens.cached_write_tokens)}
                 />
               ) : null}
               {tokens.thought_tokens !== null ? (
                 <UsageRow
                   label="Thinking"
-                  value={tokens.thought_tokens.toLocaleString()}
+                  value={exactNumber.format(tokens.thought_tokens)}
                 />
               ) : null}
             </>
@@ -695,6 +698,10 @@ export function AcpPersonaControls(
   const handlePersona = async (personaId: string | null) => {
     setPersonaAnchor(null);
     setActiveId(personaId);
+    // Usage is per persona; clearing it now keeps the previous persona's
+    // numbers from showing next to the new persona's name while the refresh
+    // is in flight.
+    setUsage(EMPTY_USAGE);
     if (chatPath) {
       await setActivePersona(chatPath, personaId);
       // Refetch so the controls follow the new active persona.

--- a/src/persona-controls.tsx
+++ b/src/persona-controls.tsx
@@ -457,15 +457,28 @@ function UsageRing(props: { fraction: number }): JSX.Element {
 }
 
 /**
- * One "label: value" row in the usage popover.
+ * A group header in the usage popover: an uppercase label with the group's
+ * headline value. Detail rows, when the group has any, follow beneath.
  */
-function UsageRow(props: {
+function UsageSection(props: {
   label: string;
   value: string;
   title?: string;
 }): JSX.Element {
   return (
-    <div className={`${USAGE_CLASS}-row`} title={props.title}>
+    <div className={`${USAGE_CLASS}-section`} title={props.title}>
+      <span>{props.label}</span>
+      <span className={`${USAGE_CLASS}-section-value`}>{props.value}</span>
+    </div>
+  );
+}
+
+/**
+ * One "label: value" detail row in the usage popover.
+ */
+function UsageRow(props: { label: string; value: string }): JSX.Element {
+  return (
+    <div className={`${USAGE_CLASS}-row`}>
       <span className={`${USAGE_CLASS}-row-label`}>{props.label}</span>
       <span className={`${USAGE_CLASS}-row-value`}>{props.value}</span>
     </div>
@@ -536,19 +549,15 @@ function UsageChip(props: { usage: AcpUsage }): JSX.Element | null {
       >
         <div className={`${USAGE_CLASS}-card`}>
           {context ? (
-            <>
-              <div className={`${USAGE_CLASS}-section`}>Context</div>
-              <UsageRow
-                label="In context now"
-                value={`${context.used.toLocaleString()} of ${formatTokens(context.size)} (${percent}%)`}
-              />
-            </>
+            <UsageSection
+              label="Context"
+              value={`${context.used.toLocaleString()} of ${formatTokens(context.size)} (${percent}%)`}
+            />
           ) : null}
           {tokens ? (
             <>
-              <div className={`${USAGE_CLASS}-section`}>Session tokens</div>
-              <UsageRow
-                label="Total"
+              <UsageSection
+                label="Session tokens"
                 value={tokens.total_tokens.toLocaleString()}
               />
               <UsageRow
@@ -580,14 +589,11 @@ function UsageChip(props: { usage: AcpUsage }): JSX.Element | null {
             </>
           ) : null}
           {cost ? (
-            <>
-              <div className={`${USAGE_CLASS}-section`}>Cost</div>
-              <UsageRow
-                label="Session estimate"
-                value={formatCost(cost.amount, cost.currency)}
-                title="Estimated at API list prices"
-              />
-            </>
+            <UsageSection
+              label="Session cost (est.)"
+              value={formatCost(cost.amount, cost.currency)}
+              title="Estimated at API list prices"
+            />
           ) : null}
         </div>
       </Popover>

--- a/src/persona-controls.tsx
+++ b/src/persona-controls.tsx
@@ -390,24 +390,24 @@ function ControlsRow(props: {
   );
 }
 
+const compactNumber = new Intl.NumberFormat('en', {
+  notation: 'compact',
+  maximumSignificantDigits: 3
+});
+
 /**
  * Format a token count compactly: 950 stays as-is, 41500 becomes "41.5k",
- * 1240000 becomes "1.24M".
+ * 1240000 becomes "1.24M". `Intl.NumberFormat` picks the tier after rounding,
+ * so boundary values like 999500 become "1M" rather than an exponential form.
  */
-function formatTokens(n: number): string {
-  if (n >= 1_000_000) {
-    return `${(n / 1_000_000).toPrecision(3)}M`;
-  }
-  if (n >= 1_000) {
-    return `${(n / 1_000).toPrecision(3)}k`;
-  }
-  return String(n);
+export function formatTokens(n: number): string {
+  return compactNumber.format(n).replace('K', 'k');
 }
 
 /**
  * Format a cost amount with its ISO 4217 currency code.
  */
-function formatCost(amount: number, currency: string): string {
+export function formatCost(amount: number, currency: string): string {
   const value = amount.toFixed(2);
   return currency === 'USD' ? `$${value}` : `${value} ${currency}`;
 }

--- a/src/persona-controls.tsx
+++ b/src/persona-controls.tsx
@@ -394,28 +394,41 @@ function ControlsRow(props: {
   );
 }
 
-// Both formatters pin the `en` locale so exact and compact numbers agree with
-// each other and with the surrounding English labels.
+// All formatters pin the `en` locale so numbers agree with each other and
+// with the surrounding English labels.
 const exactNumber = new Intl.NumberFormat('en');
 const compactNumber = new Intl.NumberFormat('en', {
   notation: 'compact',
   maximumSignificantDigits: 3
+});
+const costNumber = new Intl.NumberFormat('en', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2
 });
 
 /**
  * Format a token count compactly: 950 stays as-is, 41500 becomes "41.5k",
  * 1240000 becomes "1.24M". `Intl.NumberFormat` picks the tier after rounding,
  * so boundary values like 999500 become "1M" rather than an exponential form.
+ * Token values render compactly everywhere (magnitude is what a status surface
+ * communicates); the exact count rides on the element's hover title.
  */
 export function formatTokens(n: number): string {
   return compactNumber.format(n).replace('K', 'k');
 }
 
 /**
+ * Format a token count exactly, with thousands separators, for hover titles.
+ */
+export function formatTokensExact(n: number): string {
+  return `${exactNumber.format(n)} tokens`;
+}
+
+/**
  * Format a cost amount with its ISO 4217 currency code.
  */
 export function formatCost(amount: number, currency: string): string {
-  const value = amount.toFixed(2);
+  const value = costNumber.format(amount);
   return currency === 'USD' ? `$${value}` : `${value} ${currency}`;
 }
 
@@ -477,11 +490,16 @@ function UsageSection(props: {
 }
 
 /**
- * One "label: value" detail row in the usage popover.
+ * One "label: value" detail row in the usage popover. `title` carries the
+ * exact value behind a compact one.
  */
-function UsageRow(props: { label: string; value: string }): JSX.Element {
+function UsageRow(props: {
+  label: string;
+  value: string;
+  title?: string;
+}): JSX.Element {
   return (
-    <div className={`${USAGE_CLASS}-row`}>
+    <div className={`${USAGE_CLASS}-row`} title={props.title}>
       <span className={`${USAGE_CLASS}-row-label`}>{props.label}</span>
       <span className={`${USAGE_CLASS}-row-value`}>{props.value}</span>
     </div>
@@ -516,8 +534,8 @@ function UsageChip(props: { usage: AcpUsage }): JSX.Element | null {
 
   const summary = [
     context &&
-      `Context: ${exactNumber.format(context.used)} of ${formatTokens(context.size)} tokens (${percent}%)`,
-    tokens && `Session tokens: ${exactNumber.format(tokens.total_tokens)}`,
+      `Context: ${formatTokens(context.used)} of ${formatTokens(context.size)} tokens (${percent}%)`,
+    tokens && `Session tokens: ${formatTokens(tokens.total_tokens)}`,
     cost && `Cost: ${formatCost(cost.amount, cost.currency)}`
   ]
     .filter(Boolean)
@@ -554,39 +572,46 @@ function UsageChip(props: { usage: AcpUsage }): JSX.Element | null {
           {context ? (
             <UsageSection
               label="Context"
-              value={`${exactNumber.format(context.used)} of ${formatTokens(context.size)} (${percent}%)`}
+              value={`${formatTokens(context.used)} of ${formatTokens(context.size)} (${percent}%)`}
+              title={`${exactNumber.format(context.used)} of ${exactNumber.format(context.size)} tokens`}
             />
           ) : null}
           {tokens ? (
             <>
               <UsageSection
                 label="Session tokens"
-                value={exactNumber.format(tokens.total_tokens)}
+                value={formatTokens(tokens.total_tokens)}
+                title={formatTokensExact(tokens.total_tokens)}
               />
               <UsageRow
                 label="Input"
-                value={exactNumber.format(tokens.input_tokens)}
+                value={formatTokens(tokens.input_tokens)}
+                title={formatTokensExact(tokens.input_tokens)}
               />
               <UsageRow
                 label="Output"
-                value={exactNumber.format(tokens.output_tokens)}
+                value={formatTokens(tokens.output_tokens)}
+                title={formatTokensExact(tokens.output_tokens)}
               />
               {tokens.cached_read_tokens !== null ? (
                 <UsageRow
                   label="Cache read"
-                  value={exactNumber.format(tokens.cached_read_tokens)}
+                  value={formatTokens(tokens.cached_read_tokens)}
+                  title={formatTokensExact(tokens.cached_read_tokens)}
                 />
               ) : null}
               {tokens.cached_write_tokens !== null ? (
                 <UsageRow
                   label="Cache write"
-                  value={exactNumber.format(tokens.cached_write_tokens)}
+                  value={formatTokens(tokens.cached_write_tokens)}
+                  title={formatTokensExact(tokens.cached_write_tokens)}
                 />
               ) : null}
               {tokens.thought_tokens !== null ? (
                 <UsageRow
                   label="Thinking"
-                  value={exactNumber.format(tokens.thought_tokens)}
+                  value={formatTokens(tokens.thought_tokens)}
+                  title={formatTokensExact(tokens.thought_tokens)}
                 />
               ) : null}
             </>

--- a/src/persona-controls.tsx
+++ b/src/persona-controls.tsx
@@ -607,6 +607,7 @@ export function AcpPersonaControls(
   const [usage, setUsage] = useState<AcpUsage>(EMPTY_USAGE);
   const [personaAnchor, setPersonaAnchor] = useState<HTMLElement | null>(null);
   const [polls, setPolls] = useState(0);
+  const refreshSeq = useRef(0);
 
   const chatPath = chatModel?.name ?? null;
 
@@ -614,7 +615,13 @@ export function AcpPersonaControls(
     if (!chatPath) {
       return;
     }
+    // Refreshes overlap (message events, polling, the trailing refresh), and a
+    // slow earlier response must not overwrite a newer one's state.
+    const seq = ++refreshSeq.current;
     const response = await getActivePersona(chatPath);
+    if (seq !== refreshSeq.current) {
+      return;
+    }
     setPersonas(response.personas);
     setActiveId(response.active_id);
     setActiveName(response.active_name);

--- a/src/persona-controls.tsx
+++ b/src/persona-controls.tsx
@@ -459,9 +459,13 @@ function UsageRing(props: { fraction: number }): JSX.Element {
 /**
  * One "label: value" row in the usage popover.
  */
-function UsageRow(props: { label: string; value: string }): JSX.Element {
+function UsageRow(props: {
+  label: string;
+  value: string;
+  title?: string;
+}): JSX.Element {
   return (
-    <div className={`${USAGE_CLASS}-row`}>
+    <div className={`${USAGE_CLASS}-row`} title={props.title}>
       <span className={`${USAGE_CLASS}-row-label`}>{props.label}</span>
       <span className={`${USAGE_CLASS}-row-value`}>{props.value}</span>
     </div>
@@ -533,10 +537,15 @@ function UsageChip(props: { usage: AcpUsage }): JSX.Element | null {
         <div className={`${USAGE_CLASS}-card`}>
           {context ? (
             <>
-              <div className={`${USAGE_CLASS}-section`}>Context</div>
+              <div className={`${USAGE_CLASS}-section`}>
+                <span>Context window</span>
+                <span className={`${USAGE_CLASS}-section-value`}>
+                  {formatTokens(context.size)} tokens
+                </span>
+              </div>
               <UsageRow
                 label="In context now"
-                value={`${context.used.toLocaleString()} / ${context.size.toLocaleString()} (${percent}%)`}
+                value={`${context.used.toLocaleString()} (${percent}%)`}
               />
             </>
           ) : null}
@@ -579,8 +588,9 @@ function UsageChip(props: { usage: AcpUsage }): JSX.Element | null {
             <>
               <div className={`${USAGE_CLASS}-section`}>Cost</div>
               <UsageRow
-                label="Session"
-                value={`${formatCost(cost.amount, cost.currency)} est. at API rates`}
+                label="Session estimate"
+                value={formatCost(cost.amount, cost.currency)}
+                title="Estimated at API list prices"
               />
             </>
           ) : null}

--- a/src/persona-controls.tsx
+++ b/src/persona-controls.tsx
@@ -35,7 +35,7 @@ const USAGE_CLASS = 'jp-jupyter-ai-acp-client-usage';
 const NO_ONE_LABEL = 'No one';
 
 // Context-fill fractions at which the chip starts demanding attention: the
-// percent label appears and the ring turns warn, then error, colored.
+// ring and percent turn warn, then error, colored.
 const USAGE_WARN_AT = 0.7;
 const USAGE_ERROR_AT = 0.9;
 
@@ -469,12 +469,12 @@ function UsageRow(props: { label: string; value: string }): JSX.Element {
 }
 
 /**
- * The usage chip for the input toolbar: a small ring gauge of the active
- * persona's context-window fill, with the percent label appearing once fill
- * crosses the warn threshold. Hover shows a one-line summary; click opens a
- * popover with the full breakdown (context, session token totals, cost).
- * Renders nothing when the agent has reported no usage at all, so absence
- * reads as unknown rather than empty.
+ * The usage chip for the input toolbar: a ring gauge and percent of the active
+ * persona's context-window fill, shown next to the persona it describes, and
+ * colored once fill crosses the warn threshold. Hover shows a one-line
+ * summary; click opens a popover with the full breakdown (context, session
+ * token totals, cost). Renders nothing when the agent has reported no usage
+ * at all, so absence reads as unknown rather than empty.
  */
 function UsageChip(props: { usage: AcpUsage }): JSX.Element | null {
   const { context, tokens, cost } = props.usage;
@@ -512,9 +512,11 @@ function UsageChip(props: { usage: AcpUsage }): JSX.Element | null {
         title={summary}
         aria-label="Usage"
       >
-        {context ? <UsageRing fraction={fraction} /> : null}
-        {context && level !== 'ok' ? (
-          <span className={`${USAGE_CLASS}-pct`}>{percent}%</span>
+        {context ? (
+          <>
+            <UsageRing fraction={fraction} />
+            <span className={`${USAGE_CLASS}-pct`}>{percent}%</span>
+          </>
         ) : null}
         {!context && tokens ? (
           <span className={`${USAGE_CLASS}-pct`}>
@@ -751,14 +753,14 @@ export function AcpPersonaControls(
         </MenuItem>
       </Menu>
 
+      <UsageChip usage={usage} />
+
       {controls.length ? (
         <>
           <span className={`${SELECTOR_CLASS}-divider`} />
           <ControlsRow controls={controls} onChange={handleControl} />
         </>
       ) : null}
-
-      <UsageChip usage={usage} />
     </div>
   );
 }

--- a/src/persona-controls.tsx
+++ b/src/persona-controls.tsx
@@ -11,6 +11,7 @@ import {
   ListSubheader,
   Menu,
   MenuItem,
+  Popover,
   Switch
 } from '@mui/material';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
@@ -20,7 +21,9 @@ import { InputToolbarRegistry } from '@jupyter/chat';
 import {
   AcpControl,
   AcpControlChoice,
+  AcpUsage,
   ActivePersonaInfo,
+  EMPTY_USAGE,
   getActivePersona,
   setAcpControl,
   setActivePersona
@@ -28,7 +31,13 @@ import {
 
 const SELECTOR_CLASS = 'jp-jupyter-ai-acp-client-personaControls';
 const MENU_CLASS = 'jp-jupyter-ai-acp-client-controlMenu';
+const USAGE_CLASS = 'jp-jupyter-ai-acp-client-usage';
 const NO_ONE_LABEL = 'No one';
+
+// Context-fill fractions at which the chip starts demanding attention: the
+// percent label appears and the ring turns warn, then error, colored.
+const USAGE_WARN_AT = 0.7;
+const USAGE_ERROR_AT = 0.9;
 
 // Personas register a moment after a chat opens, and an ACP persona's controls
 // load asynchronously while its agent session initializes, which can take 20s+
@@ -382,6 +391,200 @@ function ControlsRow(props: {
 }
 
 /**
+ * Format a token count compactly: 950 stays as-is, 41500 becomes "41.5k",
+ * 1240000 becomes "1.24M".
+ */
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) {
+    return `${(n / 1_000_000).toPrecision(3)}M`;
+  }
+  if (n >= 1_000) {
+    return `${(n / 1_000).toPrecision(3)}k`;
+  }
+  return String(n);
+}
+
+/**
+ * Format a cost amount with its ISO 4217 currency code.
+ */
+function formatCost(amount: number, currency: string): string {
+  const value = amount.toFixed(2);
+  return currency === 'USD' ? `$${value}` : `${value} ${currency}`;
+}
+
+/**
+ * A ring gauge showing how full the context window is. The track is a muted
+ * full circle; the fill arc grows clockwise from 12 o'clock and takes the
+ * chip's current color, so the warn/error classes color it via `currentColor`.
+ */
+function UsageRing(props: { fraction: number }): JSX.Element {
+  const radius = 6;
+  const circumference = 2 * Math.PI * radius;
+  const clamped = Math.min(Math.max(props.fraction, 0), 1);
+  return (
+    <svg
+      className={`${USAGE_CLASS}-ring`}
+      viewBox="0 0 16 16"
+      width="16"
+      height="16"
+      aria-hidden="true"
+    >
+      <circle
+        className={`${USAGE_CLASS}-ring-track`}
+        cx="8"
+        cy="8"
+        r={radius}
+        fill="none"
+        strokeWidth="2"
+      />
+      <circle
+        className={`${USAGE_CLASS}-ring-fill`}
+        cx="8"
+        cy="8"
+        r={radius}
+        fill="none"
+        strokeWidth="2"
+        strokeDasharray={circumference}
+        strokeDashoffset={circumference * (1 - clamped)}
+        transform="rotate(-90 8 8)"
+      />
+    </svg>
+  );
+}
+
+/**
+ * One "label: value" row in the usage popover.
+ */
+function UsageRow(props: { label: string; value: string }): JSX.Element {
+  return (
+    <div className={`${USAGE_CLASS}-row`}>
+      <span className={`${USAGE_CLASS}-row-label`}>{props.label}</span>
+      <span className={`${USAGE_CLASS}-row-value`}>{props.value}</span>
+    </div>
+  );
+}
+
+/**
+ * The usage chip for the input toolbar: a small ring gauge of the active
+ * persona's context-window fill, with the percent label appearing once fill
+ * crosses the warn threshold. Hover shows a one-line summary; click opens a
+ * popover with the full breakdown (context, session token totals, cost).
+ * Renders nothing when the agent has reported no usage at all, so absence
+ * reads as unknown rather than empty.
+ */
+function UsageChip(props: { usage: AcpUsage }): JSX.Element | null {
+  const { context, tokens, cost } = props.usage;
+  const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+
+  if (!context && !tokens && !cost) {
+    return null;
+  }
+
+  const fraction =
+    context && context.size > 0 ? context.used / context.size : 0;
+  const percent = Math.round(fraction * 100);
+  const level =
+    fraction >= USAGE_ERROR_AT
+      ? 'error'
+      : fraction >= USAGE_WARN_AT
+        ? 'warn'
+        : 'ok';
+
+  const summary = [
+    context &&
+      `Context: ${context.used.toLocaleString()} / ${context.size.toLocaleString()} tokens (${percent}%)`,
+    tokens && `Session tokens: ${tokens.total_tokens.toLocaleString()}`,
+    cost && `Cost: ${formatCost(cost.amount, cost.currency)}`
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  return (
+    <>
+      <button
+        type="button"
+        className={`${USAGE_CLASS}-chip ${USAGE_CLASS}-${level}`}
+        onClick={event => setAnchor(event.currentTarget)}
+        title={summary}
+        aria-label="Usage"
+      >
+        {context ? <UsageRing fraction={fraction} /> : null}
+        {context && level !== 'ok' ? (
+          <span className={`${USAGE_CLASS}-pct`}>{percent}%</span>
+        ) : null}
+        {!context && tokens ? (
+          <span className={`${USAGE_CLASS}-pct`}>
+            {formatTokens(tokens.total_tokens)}
+          </span>
+        ) : null}
+      </button>
+      <Popover
+        anchorEl={anchor}
+        open={!!anchor}
+        onClose={() => setAnchor(null)}
+        {...menuAnchorProps}
+      >
+        <div className={`${USAGE_CLASS}-card`}>
+          {context ? (
+            <>
+              <div className={`${USAGE_CLASS}-section`}>Context</div>
+              <UsageRow
+                label="In context now"
+                value={`${context.used.toLocaleString()} / ${context.size.toLocaleString()} (${percent}%)`}
+              />
+            </>
+          ) : null}
+          {tokens ? (
+            <>
+              <div className={`${USAGE_CLASS}-section`}>Session tokens</div>
+              <UsageRow
+                label="Total"
+                value={tokens.total_tokens.toLocaleString()}
+              />
+              <UsageRow
+                label="Input"
+                value={tokens.input_tokens.toLocaleString()}
+              />
+              <UsageRow
+                label="Output"
+                value={tokens.output_tokens.toLocaleString()}
+              />
+              {tokens.cached_read_tokens !== null ? (
+                <UsageRow
+                  label="Cache read"
+                  value={tokens.cached_read_tokens.toLocaleString()}
+                />
+              ) : null}
+              {tokens.cached_write_tokens !== null ? (
+                <UsageRow
+                  label="Cache write"
+                  value={tokens.cached_write_tokens.toLocaleString()}
+                />
+              ) : null}
+              {tokens.thought_tokens !== null ? (
+                <UsageRow
+                  label="Thinking"
+                  value={tokens.thought_tokens.toLocaleString()}
+                />
+              ) : null}
+            </>
+          ) : null}
+          {cost ? (
+            <>
+              <div className={`${USAGE_CLASS}-section`}>Cost</div>
+              <UsageRow
+                label="Session"
+                value={`${formatCost(cost.amount, cost.currency)} est. at API rates`}
+              />
+            </>
+          ) : null}
+        </div>
+      </Popover>
+    </>
+  );
+}
+
+/**
  * The active-persona control for the chat input toolbar. Shows which persona
  * replies (with its avatar), lets the user switch it, and, when the active
  * persona is an ACP persona, renders its session controls (model, mode, and any
@@ -395,6 +598,7 @@ export function AcpPersonaControls(
   const [activeId, setActiveId] = useState<string | null>(null);
   const [activeName, setActiveName] = useState<string | null>(null);
   const [controls, setControls] = useState<AcpControl[]>([]);
+  const [usage, setUsage] = useState<AcpUsage>(EMPTY_USAGE);
   const [personaAnchor, setPersonaAnchor] = useState<HTMLElement | null>(null);
   const [polls, setPolls] = useState(0);
 
@@ -409,6 +613,7 @@ export function AcpPersonaControls(
     setActiveId(response.active_id);
     setActiveName(response.active_name);
     setControls(response.controls);
+    setUsage(response.usage ?? EMPTY_USAGE);
   }, [chatPath]);
 
   useEffect(() => {
@@ -537,6 +742,8 @@ export function AcpPersonaControls(
           <ControlsRow controls={controls} onChange={handleControl} />
         </>
       ) : null}
+
+      <UsageChip usage={usage} />
     </div>
   );
 }

--- a/src/persona-controls.tsx
+++ b/src/persona-controls.tsx
@@ -500,7 +500,7 @@ function UsageChip(props: { usage: AcpUsage }): JSX.Element | null {
 
   const summary = [
     context &&
-      `Context: ${context.used.toLocaleString()} / ${context.size.toLocaleString()} tokens (${percent}%)`,
+      `Context: ${context.used.toLocaleString()} of ${formatTokens(context.size)} tokens (${percent}%)`,
     tokens && `Session tokens: ${tokens.total_tokens.toLocaleString()}`,
     cost && `Cost: ${formatCost(cost.amount, cost.currency)}`
   ]
@@ -537,15 +537,10 @@ function UsageChip(props: { usage: AcpUsage }): JSX.Element | null {
         <div className={`${USAGE_CLASS}-card`}>
           {context ? (
             <>
-              <div className={`${USAGE_CLASS}-section`}>
-                <span>Context window</span>
-                <span className={`${USAGE_CLASS}-section-value`}>
-                  {formatTokens(context.size)} tokens
-                </span>
-              </div>
+              <div className={`${USAGE_CLASS}-section`}>Context</div>
               <UsageRow
                 label="In context now"
-                value={`${context.used.toLocaleString()} (${percent}%)`}
+                value={`${context.used.toLocaleString()} of ${formatTokens(context.size)} (${percent}%)`}
               />
             </>
           ) : null}

--- a/src/persona-controls.tsx
+++ b/src/persona-controls.tsx
@@ -47,6 +47,10 @@ const USAGE_ERROR_AT = 0.9;
 const POLL_MS = 1500;
 const MAX_POLLS = 24;
 
+// Delay for the one trailing refresh after a burst of message updates, long
+// enough for the turn's usage report to be stored server-side.
+const TRAILING_REFRESH_MS = 1500;
+
 // Width (px) reserved for the overflow ("...") button when not every control
 // fits inline.
 const OVERFLOW_BTN_WIDTH = 36;
@@ -617,10 +621,21 @@ export function AcpPersonaControls(
   }, [chatPath]);
 
   useEffect(() => {
+    let trailing: number | undefined;
+    const onMessages = () => {
+      refresh();
+      // The agent's usage report is stored when the prompt response resolves,
+      // a beat after the turn's final message update, so a refresh driven only
+      // by message events always misses it. One trailing refresh after the
+      // burst settles picks it up.
+      window.clearTimeout(trailing);
+      trailing = window.setTimeout(refresh, TRAILING_REFRESH_MS);
+    };
     refresh();
-    chatModel?.messagesUpdated?.connect(refresh);
+    chatModel?.messagesUpdated?.connect(onMessages);
     return () => {
-      chatModel?.messagesUpdated?.disconnect(refresh);
+      window.clearTimeout(trailing);
+      chatModel?.messagesUpdated?.disconnect(onMessages);
     };
   }, [chatModel, refresh]);
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -97,11 +97,47 @@ export type ActivePersonaInfo = {
   avatar_url: string | null;
 };
 
+export type AcpContextUsage = {
+  used: number;
+  size: number;
+};
+
+export type AcpTokenUsage = {
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  cached_read_tokens: number | null;
+  cached_write_tokens: number | null;
+  thought_tokens: number | null;
+};
+
+export type AcpCostUsage = {
+  amount: number;
+  currency: string;
+};
+
+/**
+ * The active persona's reported usage. Each field is null when the agent has
+ * not reported that quantity; some agents report none of them.
+ */
+export type AcpUsage = {
+  context: AcpContextUsage | null;
+  tokens: AcpTokenUsage | null;
+  cost: AcpCostUsage | null;
+};
+
+export const EMPTY_USAGE: AcpUsage = {
+  context: null,
+  tokens: null,
+  cost: null
+};
+
 export type ActivePersonaResponse = {
   personas: ActivePersonaInfo[];
   active_id: string | null;
   active_name: string | null;
   controls: AcpControl[];
+  usage: AcpUsage;
 };
 
 /**
@@ -115,7 +151,8 @@ export async function getActivePersona(
     personas: [],
     active_id: null,
     active_name: null,
-    controls: []
+    controls: [],
+    usage: EMPTY_USAGE
   };
   try {
     return await requestAPI<ActivePersonaResponse>(

--- a/style/base.css
+++ b/style/base.css
@@ -570,7 +570,13 @@ details[open].jp-jupyter-ai-acp-client-tool-call summary::after,
   color: var(--jp-ui-font-color1);
 }
 
+/* Group header: an uppercase label with the group's headline value on the
+   right. Detail rows, when the group has any, follow beneath. */
 .jp-jupyter-ai-acp-client-usage-section {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 16px;
   margin-top: 8px;
   padding: 8px 0 2px;
   border-top: 1px solid var(--jp-border-color2);
@@ -582,10 +588,14 @@ details[open].jp-jupyter-ai-acp-client-tool-call summary::after,
   color: var(--jp-ui-font-color1);
 }
 
-.jp-jupyter-ai-acp-client-usage-section:first-child {
-  margin-top: 0;
-  padding-top: 0;
-  border-top: none;
+/* The headline value: primary data, exempt from the label's uppercase
+   emphasis, at the same size as the detail rows. */
+.jp-jupyter-ai-acp-client-usage-section-value {
+  font-size: var(--jp-ui-font-size1);
+  font-weight: 400;
+  letter-spacing: normal;
+  text-transform: none;
+  white-space: nowrap;
 }
 
 .jp-jupyter-ai-acp-client-usage-row {
@@ -593,6 +603,13 @@ details[open].jp-jupyter-ai-acp-client-tool-call summary::after,
   justify-content: space-between;
   gap: 16px;
   line-height: 1.7;
+}
+
+/* Whatever the card starts with sits flush at the top, no divider above. */
+.jp-jupyter-ai-acp-client-usage-card > :first-child {
+  margin-top: 0;
+  padding-top: 0;
+  border-top: none;
 }
 
 .jp-jupyter-ai-acp-client-usage-row-label {

--- a/style/base.css
+++ b/style/base.css
@@ -571,10 +571,6 @@ details[open].jp-jupyter-ai-acp-client-tool-call summary::after,
 }
 
 .jp-jupyter-ai-acp-client-usage-section {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  gap: 16px;
   margin-top: 8px;
   padding: 8px 0 2px;
   border-top: 1px solid var(--jp-border-color2);
@@ -584,16 +580,6 @@ details[open].jp-jupyter-ai-acp-client-tool-call summary::after,
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--jp-ui-font-color1);
-}
-
-/* Reference value carried by a section header (e.g. the context window size):
-   a muted annotation, exempt from the header's uppercase emphasis. */
-.jp-jupyter-ai-acp-client-usage-section-value {
-  font-weight: 400;
-  letter-spacing: normal;
-  text-transform: none;
-  color: var(--jp-ui-font-color2);
-  white-space: nowrap;
 }
 
 .jp-jupyter-ai-acp-client-usage-section:first-child {

--- a/style/base.css
+++ b/style/base.css
@@ -458,16 +458,20 @@ details[open].jp-jupyter-ai-acp-client-tool-call summary::after,
   text-overflow: ellipsis;
 }
 
-/* description: secondary, one line. Long descriptions truncate (full text on
-   hover) so the menu stays clean and never sprawls. */
+/* description: secondary, wrapping to at most two lines. Agent-authored text
+   has arbitrary length, so the clamp keeps the common case fully readable and
+   bounds the pathological one (full text stays on hover). The class is doubled
+   to out-rank MUI's nowrap on the same element. */
 .jp-jupyter-ai-acp-client-controlMenu-paper
-  .jp-jupyter-ai-acp-client-controlMenu-desc {
+  .jp-jupyter-ai-acp-client-controlMenu-desc.jp-jupyter-ai-acp-client-controlMenu-desc {
   font-family: var(--jp-ui-font-family);
   font-size: var(--jp-ui-font-size0);
   color: var(--jp-ui-font-color2);
-  white-space: nowrap;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  white-space: normal;
   overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .jp-jupyter-ai-acp-client-controlMenu-check {

--- a/style/base.css
+++ b/style/base.css
@@ -509,13 +509,13 @@ details[open].jp-jupyter-ai-acp-client-tool-call summary::after,
   display: inline-flex;
   align-items: center;
   gap: 3px;
-  padding: 1px 4px;
+  padding: 1px 6px;
   border: none;
   background: transparent;
   color: var(--jp-ui-font-color2);
   border-radius: var(--jp-border-radius);
   font-family: var(--jp-ui-font-family);
-  font-size: var(--jp-ui-font-size0);
+  font-size: var(--jp-ui-font-size1);
   line-height: 1.5;
   cursor: pointer;
   flex-shrink: 0;
@@ -571,6 +571,10 @@ details[open].jp-jupyter-ai-acp-client-tool-call summary::after,
 }
 
 .jp-jupyter-ai-acp-client-usage-section {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 16px;
   margin-top: 8px;
   padding: 8px 0 2px;
   border-top: 1px solid var(--jp-border-color2);
@@ -580,6 +584,16 @@ details[open].jp-jupyter-ai-acp-client-tool-call summary::after,
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--jp-ui-font-color1);
+}
+
+/* Reference value carried by a section header (e.g. the context window size):
+   a muted annotation, exempt from the header's uppercase emphasis. */
+.jp-jupyter-ai-acp-client-usage-section-value {
+  font-weight: 400;
+  letter-spacing: normal;
+  text-transform: none;
+  color: var(--jp-ui-font-color2);
+  white-space: nowrap;
 }
 
 .jp-jupyter-ai-acp-client-usage-section:first-child {

--- a/style/base.css
+++ b/style/base.css
@@ -500,3 +500,105 @@ details[open].jp-jupyter-ai-acp-client-tool-call summary::after,
   margin-top: 0;
   border-top: none;
 }
+
+/* Usage chip: a small ring gauge of the active persona's context fill, pinned
+   at the right end of the persona-controls group. Borderless, matching the
+   overflow button. The ring fill and percent take the chip's color, so the
+   warn/error levels recolor them through `currentColor`. */
+.jp-jupyter-ai-acp-client-usage-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 4px;
+  border: none;
+  background: transparent;
+  color: var(--jp-ui-font-color2);
+  border-radius: var(--jp-border-radius);
+  font-family: var(--jp-ui-font-family);
+  font-size: var(--jp-ui-font-size0);
+  line-height: 1.5;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.jp-jupyter-ai-acp-client-usage-chip:hover {
+  background-color: var(--jp-layout-color2);
+  color: var(--jp-ui-font-color1);
+}
+
+.jp-jupyter-ai-acp-client-usage-warn {
+  color: var(--jp-warn-color1);
+}
+
+.jp-jupyter-ai-acp-client-usage-error {
+  color: var(--jp-error-color1);
+}
+
+/* Keep the threshold color on hover, only the background changes. */
+.jp-jupyter-ai-acp-client-usage-warn:hover {
+  color: var(--jp-warn-color1);
+}
+
+.jp-jupyter-ai-acp-client-usage-error:hover {
+  color: var(--jp-error-color1);
+}
+
+.jp-jupyter-ai-acp-client-usage-ring {
+  display: block;
+  flex-shrink: 0;
+}
+
+.jp-jupyter-ai-acp-client-usage-ring-track {
+  stroke: var(--jp-border-color2);
+}
+
+.jp-jupyter-ai-acp-client-usage-ring-fill {
+  stroke: currentcolor;
+}
+
+.jp-jupyter-ai-acp-client-usage-pct {
+  white-space: nowrap;
+}
+
+/* Usage popover card: labeled sections in the overflow-subheader style, then
+   one row per quantity, label muted and value right-aligned. */
+.jp-jupyter-ai-acp-client-usage-card {
+  padding: 8px 12px;
+  min-width: 220px;
+  font-family: var(--jp-ui-font-family);
+  font-size: var(--jp-ui-font-size1);
+  color: var(--jp-ui-font-color1);
+}
+
+.jp-jupyter-ai-acp-client-usage-section {
+  margin-top: 8px;
+  padding: 8px 0 2px;
+  border-top: 1px solid var(--jp-border-color2);
+  font-size: var(--jp-ui-font-size0);
+  font-weight: 700;
+  line-height: 1.5;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--jp-ui-font-color1);
+}
+
+.jp-jupyter-ai-acp-client-usage-section:first-child {
+  margin-top: 0;
+  padding-top: 0;
+  border-top: none;
+}
+
+.jp-jupyter-ai-acp-client-usage-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  line-height: 1.7;
+}
+
+.jp-jupyter-ai-acp-client-usage-row-label {
+  color: var(--jp-ui-font-color2);
+}
+
+.jp-jupyter-ai-acp-client-usage-row-value {
+  white-space: nowrap;
+}

--- a/style/base.css
+++ b/style/base.css
@@ -501,10 +501,10 @@ details[open].jp-jupyter-ai-acp-client-tool-call summary::after,
   border-top: none;
 }
 
-/* Usage chip: a small ring gauge of the active persona's context fill, pinned
-   at the right end of the persona-controls group. Borderless, matching the
-   overflow button. The ring fill and percent take the chip's color, so the
-   warn/error levels recolor them through `currentColor`. */
+/* Usage chip: a small ring gauge and percent of the active persona's context
+   fill, next to the persona it describes. Borderless, matching the overflow
+   button. The ring fill and percent take the chip's color, so the warn/error
+   levels recolor them through `currentColor`. */
 .jp-jupyter-ai-acp-client-usage-chip {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
* Fixes #107.

ACP agents report usage but the client drops it. `usage_update` (tokens currently in context, context window size, optional cumulative session cost) has no branch in `session_update` and falls through unhandled, and the token usage carried on the prompt response is never read. Users cannot see how full an agent's context window is, what a session has consumed, or what it has cost, so there is no signal for when to start a fresh chat.

This PR adds a usage chip next to the persona selector: a small ring gauge with the context fill percent always beside it, a one-line summary on hover, and a breakdown popover on click.

Backend:
- Store the latest `usage_update` and the prompt response's token usage on `BaseAcpPersona` (`acp_context_usage`, `acp_session_usage`), following the `acp_slash_commands` pattern; the client populates them in `session_update` and `prompt_and_reply`.
- Extend the `/active_persona` response with `usage {context, tokens, cost}` (`build_usage` in `routes.py`). Each field is null when the agent has not reported that quantity.

Frontend:
- Context gauge with percent of context used so far filled. The chip colors by fill threshold: neutral below 70%, warn from 70%, error from 90%.
- The popover shows context fill, the session token breakdown by type (input, output, cache read/write, thinking), and the session cost estimate.
- Large token and context counts render in compact notation (13.4k, 12.5M, 2.5B), with the exact value on hover.
- Anything the agent does not report is not shown: rows and sections are omitted, and the chip renders nothing at all when there is no usage, so absence reads as unknown rather than a false 0%. When an agent reports token usage but no context data, the chip shows the compact session token total in place of the gauge.
- Control menu descriptions now wrap to two lines instead of truncating mid-sentence.

## Automated Testing

New unit tests cover the `build_usage` shapes (nothing reported, context without cost, context with cost, token pass-through), the storageaseAcpPersona`, and the token formatter tier boundaries (999500 renders as `1M`, not exponential form). All are passing.

## Manual Testing

To test manually, open a chat (for example with Claude as the active persona, not all personas support all options) and make sure:

1. Before any message, no chip is shown (no usage reported yet).
2. Send a message; after the reply, a small ring with a percent appears right of the persona name, without any interaction.
3. Hover the chip for a one-line summary; click it for the breakdown popover (context fill, session tokens with input/output/cache/thinkin).
4. Send more messages; the chip values update on their own after each reply.
5. Switch the active persona to Kiro; the chip disappears immediately (Kiro reports no usage). Switch back to Claude; it returns with the
6. Open a model dropdown; long model descriptions wrap to two lines instead of cutting off mid-sentence.

<img width="1508" height="809" alt="Screenshot 2026-07-08 at 12 25 46 PM" src="https://github.com/user-attachments/assets/058e4126-d1e5-45eb-bce6-efb3ee1c1ee3" />

<img width="1506" height="814" alt="Screenshot 2026-07-08 at 12 25 38 PM" src="https://github.com/user-attachments/assets/250024d6-4577-4737-bc92-f81606767db8" />


When an agent reports token usage but no context data, the chip shows the compact session token total in place of the gauge:

<img width="1510" height="813" alt="Screenshot 2026-07-09 at 9 42 43 AM" src="https://github.com/user-attachments/assets/f108c7d2-6035-48d3-a50d-e2a796e8423b" />

<img width="1512" height="810" alt="Screenshot 2026-07-09 at 9 42 56 AM" src="https://github.com/user-attachments/assets/c367035d-6c4d-4c1b-bab9-658bcf4de1f3" />


