### PR TITLE
Cancel responses via persona-manager instead of a custom ACP stop route

### DIFF
--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -534,9 +534,15 @@ class BaseAcpPersona(BasePersona):
         Overrides the `BasePersona` no-op: cancels the agent's current prompt
         (via the ACP `session/cancel` notification), finalizes any messages
         streamed so far, rejects pending permissions, and clears the writing
-        state. Safe to call when nothing is in flight — a not-yet-initialized
-        session is simply ignored.
+        state.
+
+        No-op when nothing is in flight. ACP defines `session/cancel` only for an
+        ongoing prompt turn, so we skip unless the persona is actually
+        processing — the cancel handler already gates on this, but guard here too
+        for direct callers. A not-yet-initialized session is likewise ignored.
         """
+        if not self.processing:
+            return
         try:
             session_id = await self.get_session_id()
         except (AssertionError, KeyError):

--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -527,6 +527,24 @@ class BaseAcpPersona(BasePersona):
             root_dir=self.parent.root_dir,
         )
 
+    async def cancel_response(self) -> None:
+        """
+        Interrupt this persona's in-progress ACP turn.
+
+        Overrides the `BasePersona` no-op: cancels the agent's current prompt
+        (via the ACP `session/cancel` notification), finalizes any messages
+        streamed so far, rejects pending permissions, and clears the writing
+        state. Safe to call when nothing is in flight — a not-yet-initialized
+        session is simply ignored.
+        """
+        try:
+            session_id = await self.get_session_id()
+        except (AssertionError, KeyError):
+            # No ACP session yet -> nothing to cancel.
+            return
+        client = await self.get_client()
+        await client.stop_streaming(session_id)
+
     @property
     def acp_slash_commands(self) -> list[AvailableCommand]:
         """

--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -536,13 +536,11 @@ class BaseAcpPersona(BasePersona):
         streamed so far, rejects pending permissions, and clears the writing
         state.
 
-        No-op when nothing is in flight. ACP defines `session/cancel` only for an
-        ongoing prompt turn, so we skip unless the persona is actually
-        processing — the cancel handler already gates on this, but guard here too
-        for direct callers. A not-yet-initialized session is likewise ignored.
+        Only called for a persona that's actually processing (the cancel handler
+        gates on `processing`), so ACP's `session/cancel` — defined only for an
+        ongoing prompt turn — always has a turn to cancel. A not-yet-initialized
+        session is still ignored defensively.
         """
-        if not self.processing:
-            return
         try:
             session_id = await self.get_session_id()
         except (AssertionError, KeyError):

--- a/jupyter_ai_acp_client/extension_app.py
+++ b/jupyter_ai_acp_client/extension_app.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
 from jupyter_server.extension.application import ExtensionApp
-from .routes import PermissionHandler, StopStreamingHandler
+from .routes import PermissionHandler
 
 
 class JaiAcpClientExtension(ExtensionApp):
@@ -12,7 +12,6 @@ class JaiAcpClientExtension(ExtensionApp):
     name = "jupyter_ai_acp_client"
     handlers = [
         (r"ai/acp/permissions", PermissionHandler),
-        (r"ai/acp/stop/?([^/]*)?", StopStreamingHandler),
     ]
 
     def initialize_settings(self):

--- a/jupyter_ai_acp_client/routes.py
+++ b/jupyter_ai_acp_client/routes.py
@@ -1,52 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from jupyter_server.base.handlers import APIHandler
 import tornado
-from .base_acp_persona import BaseAcpPersona
-
-if TYPE_CHECKING:
-    from jupyter_server_fileid.manager import BaseFileIdManager
-    from jupyter_ai_persona_manager import PersonaManager
-
-
-class StopStreamingHandler(APIHandler):
-    @property
-    def file_id_manager(self) -> BaseFileIdManager:
-        manager = self.serverapp.web_app.settings["file_id_manager"]
-        assert manager
-        return manager
-
-    @tornado.web.authenticated
-    async def post(self, persona_mention_name: str = ""):
-        chat_path = self.get_argument('chat_path', None)
-        if not chat_path:
-            raise tornado.web.HTTPError(400, "chat_path is required as a URL query parameter")
-
-        file_id = self.file_id_manager.get_id(chat_path)
-        if not file_id:
-            raise tornado.web.HTTPError(404, f"Chat not found: {chat_path}")
-        room_id = f"text:chat:{file_id}"
-
-        persona_manager: PersonaManager | None = self.serverapp.web_app.settings.get("jupyter-ai", {}).get("persona-managers", {}).get(room_id, None)
-        if not persona_manager:
-            raise tornado.web.HTTPError(404, f"Chat not initialized: {chat_path}")
-
-        # Stop all ACP personas in this chat
-        stopped = []
-        for p in persona_manager.personas.values():
-            if not isinstance(p, BaseAcpPersona):
-                continue
-            try:
-                client = await p.get_client()
-                session_id = await p.get_session_id()
-                if session_id:
-                    await client.stop_streaming(session_id)
-                    stopped.append(p.as_user().mention_name)
-            except Exception:
-                pass
-        self.finish({"status": "stopped", "stopped": stopped})
 
 
 class PermissionHandler(APIHandler):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dependencies = [
     "jupyter_server>=2.4.0,<3",
-    "jupyter_ai_persona_manager>=0.1.0b1",
+    "jupyter_ai_persona_manager>=0.1.0b2",
     "jupyterlab_chat>=0.23.0a3",
     "agent_client_protocol>=0.11.0,<0.12.0",
     "pydantic>=2,<3",

--- a/src/request.ts
+++ b/src/request.ts
@@ -64,27 +64,19 @@ export async function submitPermissionDecision(
 }
 
 /**
- * Interrupt/stop an in-progress agent response. With no persona name, the
- * backend stops all personas in the chat.
+ * Interrupt/stop the in-progress agent response(s) in a chat.
+ *
+ * Calls the persona-manager cancel endpoint, which asks every persona in the
+ * chat to cancel its response (`BasePersona.cancel_response()`). This is
+ * backend-agnostic: ACP personas cancel their agent turn, others no-op.
  */
-export async function stopStreaming(
-  chatPath: string,
-  personaMentionName: string | null = null
-): Promise<void> {
+export async function stopStreaming(chatPath: string): Promise<void> {
   try {
-    if (personaMentionName === null) {
-      await requestAPI('ai/acp', `stop?chat_path=${chatPath}`, {
-        method: 'POST'
-      });
-    } else {
-      await requestAPI(
-        'ai/acp',
-        `stop/${personaMentionName}?chat_path=${chatPath}`,
-        {
-          method: 'POST'
-        }
-      );
-    }
+    await requestAPI(
+      'api/ai',
+      `personas/cancel?chat_path=${encodeURIComponent(chatPath)}`,
+      { method: 'POST' }
+    );
   } catch (e) {
     console.warn('Error stopping stream: ', e);
   }

--- a/src/stop-button.tsx
+++ b/src/stop-button.tsx
@@ -44,8 +44,8 @@ export function AcpStopButton(
 
     setInFlight(true);
     try {
-      // Call stop with no persona name, backend stops all personas
-      await stopStreaming(chatModel.name, null);
+      // Cancels every persona's in-progress response in this chat.
+      await stopStreaming(chatModel.name);
     } finally {
       setInFlight(false);
     }

--- a/ui-tests/fixtures/agents/slow_stream_agent.py
+++ b/ui-tests/fixtures/agents/slow_stream_agent.py
@@ -1,0 +1,77 @@
+"""
+A fake ACP agent that streams a long reply slowly — one chunk every ~200ms for
+up to ~60s — so a test has a comfortable window to interrupt it mid-stream.
+
+It counts up ("1 2 3 ...") one number per chunk. Between chunks it checks a
+cancel flag set by ACP's `session/cancel` notification (delivered to `cancel()`),
+so when the client cancels, the loop stops promptly and no further chunks land —
+letting a test assert the message stops growing and the persona stops writing.
+
+Not part of the shipped package; see AGENTS.md. Method signatures match the
+installed agent-client-protocol.
+"""
+
+import asyncio
+from typing import Any
+
+from acp import (
+    Agent,
+    InitializeResponse,
+    NewSessionResponse,
+    PromptResponse,
+    run_agent,
+    text_block,
+    update_agent_message,
+)
+from acp.interfaces import Client
+
+# Stream cadence: total ~= CHUNKS * DELAY seconds (300 * 0.2s = 60s).
+CHUNKS = 300
+DELAY_S = 0.2
+
+
+class SlowStreamAgent(Agent):
+    _conn: Client
+
+    def __init__(self) -> None:
+        # Session IDs for which a cancel has been requested.
+        self._cancelled: set[str] = set()
+
+    def on_connect(self, conn: Client) -> None:
+        self._conn = conn
+
+    async def initialize(
+        self, protocol_version: int, **kwargs: Any
+    ) -> InitializeResponse:
+        return InitializeResponse(protocol_version=protocol_version)
+
+    async def new_session(
+        self, cwd: str, mcp_servers: Any = None, **kwargs: Any
+    ) -> NewSessionResponse:
+        return NewSessionResponse(session_id="slow-stream-session")
+
+    async def cancel(self, session_id: str, **kwargs: Any) -> None:
+        # ACP delivers session/cancel here; the prompt loop checks this flag.
+        self._cancelled.add(session_id)
+
+    async def prompt(
+        self, prompt: list, session_id: str, **kwargs: Any
+    ) -> PromptResponse:
+        self._cancelled.discard(session_id)
+        for i in range(1, CHUNKS + 1):
+            if session_id in self._cancelled:
+                return PromptResponse(stop_reason="cancelled")
+            await self._conn.session_update(
+                session_id=session_id,
+                update=update_agent_message(text_block(f"{i} ")),
+            )
+            await asyncio.sleep(DELAY_S)
+        return PromptResponse(stop_reason="end_turn")
+
+
+def main() -> None:
+    asyncio.run(run_agent(SlowStreamAgent()))
+
+
+if __name__ == "__main__":
+    main()

--- a/ui-tests/fixtures/personas/slow-stream_persona.py
+++ b/ui-tests/fixtures/personas/slow-stream_persona.py
@@ -1,0 +1,45 @@
+"""
+Fixture persona: an ACP persona whose agent streams a long reply slowly, so a
+test can interrupt it mid-stream. See ../agents/slow_stream_agent.py.
+
+Not part of the shipped package. `installPersonas` copies it into a suite's
+`<dir>/.jupyter/personas/`, and the PersonaManager auto-loads it there. The
+loader only keeps classes defined in this module, so the class must be declared
+here. The fake agent path comes from `JAI_TEST_AGENTS_DIR` (exported by the
+server config).
+"""
+
+import os
+import sys
+
+import jupyter_ai_acp_client
+from jupyter_ai_acp_client.base_acp_persona import BaseAcpPersona
+from jupyter_ai_persona_manager import PersonaDefaults
+from jupyterlab_chat.models import Message
+
+_AGENTS_DIR = os.environ["JAI_TEST_AGENTS_DIR"]
+_AGENT_SCRIPT = os.path.join(_AGENTS_DIR, "slow_stream_agent.py")
+_AVATAR_PATH = os.path.join(
+    os.path.dirname(jupyter_ai_acp_client.__file__), "static", "goose.svg"
+)
+
+
+class SlowStreamTestPersona(BaseAcpPersona):
+    """Test-only ACP persona whose agent streams slowly for ~60s."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            *args, executable=[sys.executable, _AGENT_SCRIPT], **kwargs
+        )
+
+    @property
+    def defaults(self) -> PersonaDefaults:
+        return PersonaDefaults(
+            name="Slow Stream Agent",
+            description="Test-only ACP persona that streams a long reply slowly.",
+            avatar_path=_AVATAR_PATH,
+            system_prompt="unused",
+        )
+
+    async def process_message(self, message: Message) -> None:
+        await super().process_message(message)

--- a/ui-tests/tests/cancel-response.spec.ts
+++ b/ui-tests/tests/cancel-response.spec.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { expect, test } from '@jupyterlab/galata';
+import { FixturePersona, installPersonas, TestHelpers } from './test-helpers';
+
+// This suite's working directory and the fake persona installed into it.
+const TEST_DIR = 'cancel-response';
+const PERSONAS = [FixturePersona.SlowStream];
+
+/**
+ * Verifies the stop button interrupts an in-progress reply.
+ *
+ * The stop button calls the persona-manager cancel endpoint
+ * (`/api/ai/personas/cancel`), which invokes `BasePersona.cancel_response()` on
+ * each persona; `BaseAcpPersona` overrides it to cancel the agent's turn. The
+ * fixture agent streams a number every ~200ms for ~60s (slow_stream_agent.py),
+ * so there's a wide window to stop it mid-stream.
+ *
+ * After stopping we assert two things: the persona is no longer writing (the
+ * stop button disables itself, driven by the chat's writers list, which the
+ * persona leaves when its response ends), and the reply text stops growing —
+ * no further chunks land once cancelled.
+ */
+test.describe('cancel-response', () => {
+  test.beforeAll(async ({ request }) => {
+    await installPersonas(request, TEST_DIR, PERSONAS);
+  });
+
+  test('stopping a streaming reply halts writing and freezes the message', async ({
+    page
+  }) => {
+    const helpers = new TestHelpers({ dir: TEST_DIR, page });
+    await helpers.openChat();
+    await helpers.selectPersona(FixturePersona.SlowStream);
+
+    // Kick off the long stream and wait until the agent is actively writing.
+    await helpers.send('count for me');
+    await helpers.waitForWriting();
+
+    // Let a few chunks accumulate so the message is non-empty and clearly mid-stream.
+    await expect
+      .poll(async () => (await helpers.lastMessageText()).trim().length, {
+        timeout: 30000
+      })
+      .toBeGreaterThan(0);
+
+    // Interrupt.
+    await helpers.clickStop();
+
+    // The persona stops writing: the stop button disables itself.
+    await helpers.waitForNotWriting();
+
+    // The message stops growing: capture it, wait, and confirm it's unchanged.
+    const frozen = await helpers.lastMessageText();
+    await page.waitForTimeout(3000);
+    expect(await helpers.lastMessageText()).toBe(frozen);
+  });
+});

--- a/ui-tests/tests/test-helpers.ts
+++ b/ui-tests/tests/test-helpers.ts
@@ -37,7 +37,8 @@ export enum FixturePersona {
   ConfigMode = 'config-mode',
   BothMode = 'both-mode',
   DuplicateGroups = 'duplicate-groups',
-  SlashCommands = 'slash-commands'
+  SlashCommands = 'slash-commands',
+  SlowStream = 'slow-stream'
 }
 
 interface FixturePersonaInfo {
@@ -58,7 +59,8 @@ export const FIXTURE_PERSONAS: Record<FixturePersona, FixturePersonaInfo> = {
   [FixturePersona.ConfigMode]: { name: 'Config Mode Agent' },
   [FixturePersona.BothMode]: { name: 'Both Mode Agent' },
   [FixturePersona.DuplicateGroups]: { name: 'Duplicate Groups Agent' },
-  [FixturePersona.SlashCommands]: { name: 'Slash Commands Agent' }
+  [FixturePersona.SlashCommands]: { name: 'Slash Commands Agent' },
+  [FixturePersona.SlowStream]: { name: 'Slow Stream Agent' }
 };
 
 const PICKER = '.jp-jupyter-ai-acp-client-personaControls-persona-btn';
@@ -73,6 +75,9 @@ const MESSAGE = '.jp-chat-rendered-message';
 // Each slash-command completion in the input's autocomplete popup renders its
 // name in a `.jp-chat-command-name` span (MUI list options, page-scoped portal).
 const COMMAND_NAME = '.jp-chat-command-name';
+// The toolbar's stop button: enabled only while an AI persona is writing, so its
+// disabled state doubles as a "is the persona still streaming?" signal.
+const STOP_BUTTON = '.jp-jupyter-ai-acp-client-stopButton';
 
 // The usage chip and the parts that distinguish which usage channel an agent
 // reported: a context ring + percent (session/usage) and/or a session-token
@@ -264,5 +269,49 @@ export class TestHelpers {
       )
       .toBe(true);
     return last;
+  }
+
+  /**
+   * Type a message and click send, without waiting for the reply to finish.
+   * Use when the reply is long-running (e.g. a slow stream) and the test drives
+   * what happens mid-stream.
+   */
+  async send(text: string): Promise<void> {
+    await this.chat
+      .locator(INPUT)
+      .getByRole('combobox')
+      .pressSequentially(text);
+    await this.chat.locator(`${INPUT} .jp-chat-send-button`).click();
+  }
+
+  /** The toolbar's stop button (a single toolbar item, rendered once). */
+  get stopButton(): Locator {
+    return this.chat.locator(STOP_BUTTON);
+  }
+
+  /**
+   * Wait until an AI persona is actively writing — the stop button becomes
+   * enabled. Returns once the persona is streaming.
+   */
+  async waitForWriting(): Promise<void> {
+    await expect(this.stopButton).toBeEnabled({ timeout: TIMEOUT });
+  }
+
+  /** Click the stop button to interrupt the in-progress response. */
+  async clickStop(): Promise<void> {
+    await this.stopButton.click();
+  }
+
+  /**
+   * Wait until no AI persona is writing — the stop button is disabled again.
+   * This is the awareness-driven signal that the persona stopped streaming.
+   */
+  async waitForNotWriting(): Promise<void> {
+    await expect(this.stopButton).toBeDisabled({ timeout: TIMEOUT });
+  }
+
+  /** The text of the latest rendered message (the agent's streaming reply). */
+  async lastMessageText(): Promise<string> {
+    return (await this.chat.locator(MESSAGE).last().textContent()) ?? '';
   }
 }


### PR DESCRIPTION
## Motivation

We're moving the chat input toolbar into jupyter-ai-persona-manager, since it depends only on the awareness channel and message metadata. The last backend-specific toolbar item is the stop button: today it lives here and calls an ACP-only REST route to cancel an agent turn. For the button to live in the shared toolbar, cancellation has to be backend-agnostic.

This is a reference PR demonstrating the ACP side of that, on top of the new `BasePersona.cancel_response()` and `/api/ai/personas/cancel` endpoint (jupyter-ai-contrib/jupyter-ai-persona-manager#66). It's here to verify the end-to-end flow works; a reviewer can decide whether to land it as-is or fold it into the larger UI migration.

## Summary

`BaseAcpPersona` now implements `cancel_response()` to cancel its in-progress agent turn — the same work the old stop route did (send ACP `session/cancel`, finalize streamed messages, reject pending permissions, clear the writing state).

The ACP-specific stop route and its handler are removed. The frontend stop button now calls persona-manager's `/api/ai/personas/cancel` endpoint, which asks every persona in the chat to cancel via `cancel_response()`. Nothing about the button is ACP-specific anymore.

## Technical details

Depends on the persona-manager cancel endpoint (#66). The `jupyter_ai_persona_manager` floor is bumped to `0.1.0b2`, so CI here will be red until that release is published — expected, not a regression. Verified locally against the unreleased persona-manager build.

## Testing

Adds an E2E suite: a fake agent that streams a number every ~200ms for ~60s, so the reply can be interrupted mid-stream. After clicking stop, it asserts the persona is no longer writing (the stop button disables itself) and the reply text stops growing.