### PR TITLE
Fix HTTP 500 on permission Allow: import BaseAcpPersona in routes.py

### DIFF
--- a/jupyter_ai_acp_client/routes.py
+++ b/jupyter_ai_acp_client/routes.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from jupyter_server.base.handlers import APIHandler
 import tornado
 
+from .base_acp_persona import BaseAcpPersona
+
 
 class PermissionHandler(APIHandler):
     """


### PR DESCRIPTION
## Problem

Clicking **Allow** on an agent's permission prompt returns **HTTP 500**, and the approval never resolves — the agent's tool call stays blocked.

`PermissionHandler._find_client_for_session` in `routes.py` does:

```python
if not isinstance(persona, BaseAcpPersona):
```

but `routes.py` only imports `APIHandler` and `tornado` — `BaseAcpPersona` is never imported, so the `isinstance` check raises `NameError` on every `POST /ai/acp/permissions`, surfaced by Tornado as a 500.

## Fix

Add the missing import:

```python
from .base_acp_persona import BaseAcpPersona
```

## Verification

- `import jupyter_ai_acp_client.routes as r; hasattr(r, "BaseAcpPersona")` → was `False`, now `True`.
- No circular import: `base_acp_persona` does not import `routes`.
- With the import added, the **Allow** button resolves permissions and the agent proceeds (tested against jupyter-ai 3.1.0 / JupyterLab 4.6.2 with the built-in Claude persona via `@zed-industries/claude-agent-acp`).

Fixes #147.
