### PR TITLE
Fix missing import

### DIFF
--- a/jupyter_ai_acp_client/routes.py
+++ b/jupyter_ai_acp_client/routes.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from jupyter_server.base.handlers import APIHandler
 import tornado
 
+from .base_acp_persona import BaseAcpPersona
+
 
 class PermissionHandler(APIHandler):
     """


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyter-ai/issues/1623

The allow/disallow interaction was not working in chat. It was non-responsive. This PR fixes that error. 

Change: Adds the missing import from `.base_acp_persona import BaseAcpPersona` to [jupyter_ai_acp_client/routes.py](vscode-webview://1o118qfb2jsecc4rta0mp9jktnetsid9ltcl1nsm23a83btre95h/jupyter-ai-acp-client/jupyter_ai_acp_client/routes.py#L6).

Why it matters: The `PermissionHandler._find_client_for_session method` at [routes.py:36](vscode-webview://1o118qfb2jsecc4rta0mp9jktnetsid9ltcl1nsm23a83btre95h/jupyter-ai-acp-client/jupyter_ai_acp_client/routes.py#L36) uses isinstance(persona, BaseAcpPersona) to filter personas, but BaseAcpPersona was never imported. This caused a NameError at runtime whenever a user clicked an allow/disallow button in chat, making the ACP permission interaction non-responsive. The 2-line diff (blank line + import) resolves the failure.

<img width="621" height="747" alt="Screenshot 2026-07-27 at 10 36 54 AM" src="https://github.com/user-attachments/assets/50ae8510-4716-4451-b936-5efc9914b7c4" />

