### PR TITLE
Decouple requirements checking from import time

### DIFF
--- a/jupyter_ai_acp_client/acp_personas/claude.py
+++ b/jupyter_ai_acp_client/acp_personas/claude.py
@@ -1,13 +1,6 @@
-import shutil
-from jupyter_ai_persona_manager import PersonaRequirementsUnmet
-if shutil.which("claude-agent-acp") is None:
-    raise PersonaRequirementsUnmet(
-        "This persona requires the Claude Agent ACP adapter to be installed."
-        " Install it via `npm install -g @zed-industries/claude-agent-acp`"
-        " then restart."
-    )
-
 import os
+import shutil
+
 from jupyter_ai_persona_manager import PersonaDefaults
 from jupyterlab_chat.models import Message
 from acp.exceptions import RequestError
@@ -36,7 +29,16 @@ class ClaudeAcpPersona(BaseAcpPersona):
     def __init__(self, *args, **kwargs):
         executable = ["claude-agent-acp"]
         super().__init__(*args, executable=executable, **kwargs)
-    
+
+    def check_requirements(self) -> str | None:
+        if shutil.which("claude-agent-acp") is None:
+            return (
+                "This persona requires the Claude Agent ACP adapter to be installed."
+                " Install it via `npm install -g @zed-industries/claude-agent-acp`"
+                " then restart."
+            )
+        return None
+
     @property
     def defaults(self) -> PersonaDefaults:
         avatar_path = str(os.path.abspath(

--- a/jupyter_ai_acp_client/acp_personas/codex.py
+++ b/jupyter_ai_acp_client/acp_personas/codex.py
@@ -2,24 +2,25 @@ import os
 import shutil
 
 from acp.exceptions import RequestError
-from jupyter_ai_persona_manager import PersonaDefaults, PersonaRequirementsUnmet
+from jupyter_ai_persona_manager import PersonaDefaults
 from jupyterlab_chat.models import Message
 
 from ..base_acp_persona import BaseAcpPersona
-
-
-if shutil.which("codex-acp") is None:
-    raise PersonaRequirementsUnmet(
-        "This persona requires `codex-acp`, the ACP adapter for OpenAI Codex."
-        " Install it via `npm install -g @zed-industries/codex-acp`"
-        " then restart."
-    )
 
 
 class CodexAcpPersona(BaseAcpPersona):
     def __init__(self, *args, **kwargs):
         executable = ["codex-acp"]
         super().__init__(*args, executable=executable, **kwargs)
+
+    def check_requirements(self) -> str | None:
+        if shutil.which("codex-acp") is None:
+            return (
+                "This persona requires `codex-acp`, the ACP adapter for OpenAI Codex."
+                " Install it via `npm install -g @zed-industries/codex-acp`"
+                " then restart."
+            )
+        return None
 
     @property
     def defaults(self) -> PersonaDefaults:

--- a/jupyter_ai_acp_client/acp_personas/copilot.py
+++ b/jupyter_ai_acp_client/acp_personas/copilot.py
@@ -2,7 +2,7 @@ import os
 import shutil
 
 from acp.exceptions import RequestError
-from jupyter_ai_persona_manager import PersonaDefaults, PersonaRequirementsUnmet
+from jupyter_ai_persona_manager import PersonaDefaults
 from jupyterlab_chat.models import Message
 
 from ..base_acp_persona import BaseAcpPersona
@@ -25,22 +25,19 @@ def _is_auth_error(error: Exception) -> bool:
     )
 
 
-def _check_copilot() -> None:
-    if shutil.which("copilot") is None:
-        raise PersonaRequirementsUnmet(
-            "This persona requires the GitHub Copilot CLI."
-            " Install it via https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli"
-            " and restart."
-        )
-
-
-_check_copilot()
-
-
 class CopilotAcpPersona(BaseAcpPersona):
     def __init__(self, *args, **kwargs):
         executable = ["copilot", "--acp", "--stdio"]
         super().__init__(*args, executable=executable, **kwargs)
+
+    def check_requirements(self) -> str | None:
+        if shutil.which("copilot") is None:
+            return (
+                "This persona requires the GitHub Copilot CLI."
+                " Install it via https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli"
+                " and restart."
+            )
+        return None
 
     @property
     def defaults(self) -> PersonaDefaults:

--- a/jupyter_ai_acp_client/acp_personas/goose.py
+++ b/jupyter_ai_acp_client/acp_personas/goose.py
@@ -4,7 +4,7 @@ import shutil
 import subprocess
 
 from acp.exceptions import RequestError
-from jupyter_ai_persona_manager import PersonaDefaults, PersonaRequirementsUnmet
+from jupyter_ai_persona_manager import PersonaDefaults
 from jupyterlab_chat.models import Message
 
 from ..base_acp_persona import BaseAcpPersona
@@ -32,70 +32,68 @@ def _is_setup_error(error: Exception) -> bool:
     return "failed to set provider" in data or "failed to create" in data
 
 
-def _check_goose():
-    """Verify goose is installed and has ACP support (>= 1.8.0, < 2)."""
-    if shutil.which("goose") is None:
-        raise PersonaRequirementsUnmet(
-            "This persona requires the Goose CLI."
-            " See https://github.com/block/goose for installation instructions."
-        )
-
-    try:
-        result = subprocess.run(
-            ["goose", "--version"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-
-        if result.returncode != 0:
-            stderr = result.stderr.strip()
-            error_msg = (
-                f"goose --version returned non-zero exit code {result.returncode}."
-                " Please ensure goose is properly installed."
-            )
-            if stderr:
-                error_msg += f"\nStderr output: {stderr}"
-            raise PersonaRequirementsUnmet(error_msg)
-
-        version_match = re.search(r"(\d+\.\d+\.\d+)", result.stdout)
-        if not version_match:
-            raise PersonaRequirementsUnmet(
-                "Could not extract version number from goose --version output."
-                f" Got: {result.stdout.strip()}"
-            )
-
-        version_str = version_match.group(1)
-        version_parts = [int(x) for x in version_str.split(".")]
-        current_version = tuple(version_parts)
-        required_version = (1, 8, 0)
-
-        if current_version < required_version or current_version[0] >= 2:
-            raise PersonaRequirementsUnmet(
-                f"Goose version {version_str} is installed,"
-                " but version >=1.8.0,<2 is required."
-                " See https://github.com/block/goose for instructions."
-            )
-
-    except subprocess.TimeoutExpired:
-        raise PersonaRequirementsUnmet(
-            "goose --version command timed out."
-            " Please ensure goose is properly installed."
-        )
-    except FileNotFoundError:
-        raise PersonaRequirementsUnmet(
-            "goose command not found."
-            " Please ensure goose is properly installed."
-        )
-
-
-_check_goose()
-
-
 class GooseAcpPersona(BaseAcpPersona):
     def __init__(self, *args, **kwargs):
         executable = ["goose", "acp"]
         super().__init__(*args, executable=executable, **kwargs)
+
+    def check_requirements(self) -> str | None:
+        """Verify goose is installed and has ACP support (>= 1.8.0, < 2)."""
+        if shutil.which("goose") is None:
+            return (
+                "This persona requires the Goose CLI."
+                " See https://github.com/block/goose for installation instructions."
+            )
+
+        try:
+            result = subprocess.run(
+                ["goose", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+
+            if result.returncode != 0:
+                stderr = result.stderr.strip()
+                error_msg = (
+                    f"goose --version returned non-zero exit code {result.returncode}."
+                    " Please ensure goose is properly installed."
+                )
+                if stderr:
+                    error_msg += f"\nStderr output: {stderr}"
+                return error_msg
+
+            version_match = re.search(r"(\d+\.\d+\.\d+)", result.stdout)
+            if not version_match:
+                return (
+                    "Could not extract version number from goose --version output."
+                    f" Got: {result.stdout.strip()}"
+                )
+
+            version_str = version_match.group(1)
+            version_parts = [int(x) for x in version_str.split(".")]
+            current_version = tuple(version_parts)
+            required_version = (1, 8, 0)
+
+            if current_version < required_version or current_version[0] >= 2:
+                return (
+                    f"Goose version {version_str} is installed,"
+                    " but version >=1.8.0,<2 is required."
+                    " See https://github.com/block/goose for instructions."
+                )
+
+        except subprocess.TimeoutExpired:
+            return (
+                "goose --version command timed out."
+                " Please ensure goose is properly installed."
+            )
+        except FileNotFoundError:
+            return (
+                "goose command not found."
+                " Please ensure goose is properly installed."
+            )
+
+        return None
 
     @property
     def defaults(self) -> PersonaDefaults:

--- a/jupyter_ai_acp_client/acp_personas/kilo.py
+++ b/jupyter_ai_acp_client/acp_personas/kilo.py
@@ -3,76 +3,73 @@ import re
 import shutil
 import subprocess
 
-from jupyter_ai_persona_manager import PersonaDefaults, PersonaRequirementsUnmet
+from jupyter_ai_persona_manager import PersonaDefaults
 from jupyterlab_chat.models import Message
 from ..base_acp_persona import BaseAcpPersona
 from acp.exceptions import RequestError
 
-# Raise `PersonaRequirementsUnmet` if `kilo` not installed
-if shutil.which("kilo") is None:
-    raise PersonaRequirementsUnmet(
-        "This persona requires `kilo` to be installed."
-        " See https://kilo.ai/docs/getting-started for installation instructions."
-    )
-
-# Raise `PersonaRequirementsUnmet` if `kilo<7.0.0`
-try:
-    result = subprocess.run(
-        ["kilo", "acp", "--version"],
-        capture_output=True,
-        text=True,
-        timeout=5
-    )
-
-    # Check for non-zero exit code
-    if result.returncode != 0:
-        stderr = result.stderr.strip()
-        error_msg = (
-            f"kilo --version returned non-zero exit code {result.returncode}."
-            " Please ensure kilo is properly installed."
-        )
-        if stderr:
-            error_msg += f"\nStderr output: {stderr}"
-
-        raise PersonaRequirementsUnmet(error_msg)
-
-    # Extract semver from stdout using regex
-    version_match = re.search(r'(\d+\.\d+\.\d+)', result.stdout)
-    if not version_match:
-        raise PersonaRequirementsUnmet(
-            "Could not extract version number from kilo --version output."
-            f" Got: {result.stdout.strip()}"
-        )
-
-    version_str = version_match.group(1)
-    version_parts = [int(x) for x in version_str.split('.')]
-
-    # Check if version >= 7.0.0
-    required_version = (7, 0, 0)
-    current_version = tuple(version_parts)
-
-    if current_version < required_version:
-        raise PersonaRequirementsUnmet(
-            f"kilo version {version_str} is installed, but version >=7.0.0 is required."
-            " Please upgrade kilo. See https://kilo.ai/ for instructions."
-        )
-
-except subprocess.TimeoutExpired:
-    raise PersonaRequirementsUnmet(
-        "kilo acp --version command timed out."
-        " Please ensure kilo is properly installed."
-    )
-except FileNotFoundError:
-    # This shouldn't happen since we checked with shutil.which, but handle it anyway
-    raise PersonaRequirementsUnmet(
-        "kilo command not found."
-        " Please ensure kilo is properly installed."
-    )
 
 class KiloAcpPersona(BaseAcpPersona):
     def __init__(self, *args, **kwargs):
         executable = ["kilo", "acp"]
         super().__init__(*args, executable=executable, **kwargs)
+
+    def check_requirements(self) -> str | None:
+        """Check that kilo is installed and meets version requirements."""
+        if shutil.which("kilo") is None:
+            return (
+                "This persona requires `kilo` to be installed."
+                " See https://kilo.ai/docs/getting-started for installation instructions."
+            )
+
+        try:
+            result = subprocess.run(
+                ["kilo", "acp", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=5
+            )
+
+            if result.returncode != 0:
+                stderr = result.stderr.strip()
+                error_msg = (
+                    f"kilo --version returned non-zero exit code {result.returncode}."
+                    " Please ensure kilo is properly installed."
+                )
+                if stderr:
+                    error_msg += f"\nStderr output: {stderr}"
+                return error_msg
+
+            version_match = re.search(r'(\d+\.\d+\.\d+)', result.stdout)
+            if not version_match:
+                return (
+                    "Could not extract version number from kilo --version output."
+                    f" Got: {result.stdout.strip()}"
+                )
+
+            version_str = version_match.group(1)
+            version_parts = [int(x) for x in version_str.split('.')]
+            required_version = (7, 0, 0)
+            current_version = tuple(version_parts)
+
+            if current_version < required_version:
+                return (
+                    f"kilo version {version_str} is installed, but version >=7.0.0 is required."
+                    " Please upgrade kilo. See https://kilo.ai/ for instructions."
+                )
+
+        except subprocess.TimeoutExpired:
+            return (
+                "kilo acp --version command timed out."
+                " Please ensure kilo is properly installed."
+            )
+        except FileNotFoundError:
+            return (
+                "kilo command not found."
+                " Please ensure kilo is properly installed."
+            )
+
+        return None
 
     @property
     def defaults(self) -> PersonaDefaults:

--- a/jupyter_ai_acp_client/acp_personas/kiro.py
+++ b/jupyter_ai_acp_client/acp_personas/kiro.py
@@ -9,73 +9,12 @@ from typing import ClassVar, Optional
 from jupyter_ai_persona_manager import (
     ModelOption,
     PersonaDefaults,
-    PersonaRequirementsUnmet,
 )
 from jupyterlab_chat.models import Message
 from ..base_acp_persona import BaseAcpPersona
 from ..default_acp_client import JaiAcpClient
 from ..kiro_client import KiroAcpClient, KiroModels
 
-# Raise `PersonaRequirementsUnmet` if `kiro-cli` not installed
-if shutil.which("kiro-cli") is None:
-    raise PersonaRequirementsUnmet(
-        "This persona requires `kiro-cli` to be installed."
-        " See https://kiro.dev for installation instructions."
-    )
-
-# Raise `PersonaRequirementsUnmet` if `kiro-cli<1.25.0`
-try:
-    result = subprocess.run(
-        ["kiro-cli", "--version"],
-        capture_output=True,
-        text=True,
-        timeout=5
-    )
-
-    # Check for non-zero exit code
-    if result.returncode != 0:
-        stderr = result.stderr.strip()
-        error_msg = (
-            f"kiro-cli --version returned non-zero exit code {result.returncode}."
-            " Please ensure kiro-cli is properly installed."
-        )
-        if stderr:
-            error_msg += f"\nStderr output: {stderr}"
-
-        raise PersonaRequirementsUnmet(error_msg)
-
-    # Extract semver from stdout using regex
-    version_match = re.search(r'(\d+\.\d+\.\d+)', result.stdout)
-    if not version_match:
-        raise PersonaRequirementsUnmet(
-            "Could not extract version number from kiro-cli --version output."
-            f" Got: {result.stdout.strip()}"
-        )
-
-    version_str = version_match.group(1)
-    version_parts = [int(x) for x in version_str.split('.')]
-
-    # Check if version >= 1.25.0
-    required_version = (1, 25, 0)
-    current_version = tuple(version_parts)
-
-    if current_version < required_version or current_version[0] >= 3:
-        raise PersonaRequirementsUnmet(
-            f"kiro-cli version {version_str} is installed, but version >=1.25.0,<3 is required."
-            " Please upgrade kiro-cli. See https://kiro.dev for instructions."
-        )
-
-except subprocess.TimeoutExpired:
-    raise PersonaRequirementsUnmet(
-        "kiro-cli --version command timed out."
-        " Please ensure kiro-cli is properly installed."
-    )
-except FileNotFoundError:
-    # This shouldn't happen since we checked with shutil.which, but handle it anyway
-    raise PersonaRequirementsUnmet(
-        "kiro-cli command not found."
-        " Please ensure kiro-cli is properly installed."
-    )
 
 class KiroAcpPersona(BaseAcpPersona):
     _terminal_opened: bool
@@ -93,6 +32,63 @@ class KiroAcpPersona(BaseAcpPersona):
         # response (`None` until a session is created/loaded). Kiro advertises
         # models this way instead of through ACP v1 config options.
         self._kiro_models: Optional[KiroModels] = None
+
+    def check_requirements(self) -> str | None:
+        """Check that kiro-cli is installed and meets version requirements."""
+        if shutil.which("kiro-cli") is None:
+            return (
+                "This persona requires `kiro-cli` to be installed."
+                " See https://kiro.dev for installation instructions."
+            )
+
+        try:
+            result = subprocess.run(
+                ["kiro-cli", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=5
+            )
+
+            if result.returncode != 0:
+                stderr = result.stderr.strip()
+                error_msg = (
+                    f"kiro-cli --version returned non-zero exit code {result.returncode}."
+                    " Please ensure kiro-cli is properly installed."
+                )
+                if stderr:
+                    error_msg += f"\nStderr output: {stderr}"
+                return error_msg
+
+            version_match = re.search(r'(\d+\.\d+\.\d+)', result.stdout)
+            if not version_match:
+                return (
+                    "Could not extract version number from kiro-cli --version output."
+                    f" Got: {result.stdout.strip()}"
+                )
+
+            version_str = version_match.group(1)
+            version_parts = [int(x) for x in version_str.split('.')]
+            required_version = (1, 25, 0)
+            current_version = tuple(version_parts)
+
+            if current_version < required_version or current_version[0] >= 3:
+                return (
+                    f"kiro-cli version {version_str} is installed, but version >=1.25.0,<3 is required."
+                    " Please upgrade kiro-cli. See https://kiro.dev for instructions."
+                )
+
+        except subprocess.TimeoutExpired:
+            return (
+                "kiro-cli --version command timed out."
+                " Please ensure kiro-cli is properly installed."
+            )
+        except FileNotFoundError:
+            return (
+                "kiro-cli command not found."
+                " Please ensure kiro-cli is properly installed."
+            )
+
+        return None
 
     def set_kiro_models(self, models: Optional[KiroModels]) -> None:
         """

--- a/jupyter_ai_acp_client/acp_personas/mistral_vibe.py
+++ b/jupyter_ai_acp_client/acp_personas/mistral_vibe.py
@@ -2,7 +2,7 @@ import os
 import shutil
 
 from acp.exceptions import RequestError
-from jupyter_ai_persona_manager import PersonaDefaults, PersonaRequirementsUnmet
+from jupyter_ai_persona_manager import PersonaDefaults
 from jupyterlab_chat.models import Message
 
 from ..base_acp_persona import BaseAcpPersona
@@ -23,18 +23,19 @@ def _is_auth_error(error: Exception) -> bool:
     )
 
 
-if shutil.which("vibe-acp") is None:
-    raise PersonaRequirementsUnmet(
-        "This persona requires `vibe-acp`, which is provided by the `mistral-vibe` package."
-        " Install it via `uv tool install mistral-vibe`, `pip install mistral-vibe`,"
-        " or Mistral's install script, then restart."
-    )
-
-
 class MistralVibeAcpPersona(BaseAcpPersona):
     def __init__(self, *args, **kwargs):
         executable = ["vibe-acp"]
         super().__init__(*args, executable=executable, **kwargs)
+
+    def check_requirements(self) -> str | None:
+        if shutil.which("vibe-acp") is None:
+            return (
+                "This persona requires `vibe-acp`, which is provided by the `mistral-vibe` package."
+                " Install it via `uv tool install mistral-vibe`, `pip install mistral-vibe`,"
+                " or Mistral's install script, then restart."
+            )
+        return None
 
     @property
     def defaults(self) -> PersonaDefaults:

--- a/jupyter_ai_acp_client/acp_personas/opencode.py
+++ b/jupyter_ai_acp_client/acp_personas/opencode.py
@@ -6,7 +6,7 @@ from asyncio.subprocess import Process
 from pathlib import Path
 
 from acp.exceptions import RequestError
-from jupyter_ai_persona_manager import PersonaDefaults, PersonaRequirementsUnmet
+from jupyter_ai_persona_manager import PersonaDefaults
 from jupyterlab_chat.models import Message
 
 from ..base_acp_persona import BaseAcpPersona
@@ -39,67 +39,65 @@ def _is_auth_error(error: Exception) -> bool:
     )
 
 
-def _check_opencode() -> None:
-    """Raise PersonaRequirementsUnmet if opencode is missing or wrong version."""
-    if shutil.which("opencode") is None:
-        raise PersonaRequirementsUnmet(
-            "This persona requires `opencode` to be installed."
-            " See https://opencode.ai for installation instructions."
-        )
-
-    try:
-        result = subprocess.run(
-            ["opencode", "--version"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-    except subprocess.TimeoutExpired:
-        raise PersonaRequirementsUnmet(
-            "opencode --version command timed out."
-            " Please ensure opencode is properly installed."
-        )
-    except FileNotFoundError:
-        raise PersonaRequirementsUnmet(
-            "opencode command not found."
-            " Please ensure opencode is properly installed."
-        )
-
-    if result.returncode != 0:
-        stderr = result.stderr.strip()
-        error_msg = (
-            f"opencode --version returned non-zero exit code {result.returncode}."
-            " Please ensure opencode is properly installed."
-        )
-        if stderr:
-            error_msg += f"\nStderr output: {stderr}"
-        raise PersonaRequirementsUnmet(error_msg)
-
-    version_match = re.search(r"(\d+\.\d+\.\d+)", result.stdout)
-    if not version_match:
-        raise PersonaRequirementsUnmet(
-            "Could not extract version number from opencode --version output."
-            f" Got: {result.stdout.strip()}"
-        )
-
-    version_str = version_match.group(1)
-    current_version = tuple(int(x) for x in version_str.split("."))
-
-    if current_version < (1, 0, 0) or current_version[0] >= 2:
-        raise PersonaRequirementsUnmet(
-            f"opencode version {version_str} is installed,"
-            " but version >=1.0.0,<2 is required."
-            " Please upgrade opencode. See https://opencode.ai for instructions."
-        )
-
-
-_check_opencode()
-
-
 class OpenCodeAcpPersona(BaseAcpPersona):
     def __init__(self, *args, **kwargs):
         executable = ["opencode", "acp"]
         super().__init__(*args, executable=executable, **kwargs)
+
+    def check_requirements(self) -> str | None:
+        """Check that opencode is installed and meets version requirements."""
+        if shutil.which("opencode") is None:
+            return (
+                "This persona requires `opencode` to be installed."
+                " See https://opencode.ai for installation instructions."
+            )
+
+        try:
+            result = subprocess.run(
+                ["opencode", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except subprocess.TimeoutExpired:
+            return (
+                "opencode --version command timed out."
+                " Please ensure opencode is properly installed."
+            )
+        except FileNotFoundError:
+            return (
+                "opencode command not found."
+                " Please ensure opencode is properly installed."
+            )
+
+        if result.returncode != 0:
+            stderr = result.stderr.strip()
+            error_msg = (
+                f"opencode --version returned non-zero exit code {result.returncode}."
+                " Please ensure opencode is properly installed."
+            )
+            if stderr:
+                error_msg += f"\nStderr output: {stderr}"
+            return error_msg
+
+        version_match = re.search(r"(\d+\.\d+\.\d+)", result.stdout)
+        if not version_match:
+            return (
+                "Could not extract version number from opencode --version output."
+                f" Got: {result.stdout.strip()}"
+            )
+
+        version_str = version_match.group(1)
+        current_version = tuple(int(x) for x in version_str.split("."))
+
+        if current_version < (1, 0, 0) or current_version[0] >= 2:
+            return (
+                f"opencode version {version_str} is installed,"
+                " but version >=1.0.0,<2 is required."
+                " Please upgrade opencode. See https://opencode.ai for instructions."
+            )
+
+        return None
 
     @property
     def defaults(self) -> PersonaDefaults:

--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -162,40 +162,56 @@ class BaseAcpPersona(BasePersona):
         self._executable = executable
         self._pending_session_recovery_context: bool = False
         self._was_initially_unauthenticated: bool = False
+        self._requirements_met: bool = self.check_requirements() is None
 
-        # Ensure each subclass has its own subprocess and client by checking if the
-        # class variable is defined directly on this class (not inherited)
-        if (
-            "_before_subprocess_future" not in self.__class__.__dict__
-            or self.__class__._before_subprocess_future is None
-        ):
-            self.__class__._before_subprocess_future = self.event_loop.create_task(
-                self.before_agent_subprocess()
-            )
-        if (
-            "_subprocess_future" not in self.__class__.__dict__
-            or self.__class__._subprocess_future is None
-        ):
-            self.__class__._subprocess_future = self.event_loop.create_task(
-                self._init_agent_subprocess()
-            )
-        if (
-            "_client_future" not in self.__class__.__dict__
-            or self.__class__._client_future is None
-        ):
-            self.__class__._client_future = self.event_loop.create_task(
-                self._init_client()
+        # Only start subprocess/client/session if requirements are met
+        if self._requirements_met:
+            # Ensure each subclass has its own subprocess and client by checking if the
+            # class variable is defined directly on this class (not inherited)
+            if (
+                "_before_subprocess_future" not in self.__class__.__dict__
+                or self.__class__._before_subprocess_future is None
+            ):
+                self.__class__._before_subprocess_future = self.event_loop.create_task(
+                    self.before_agent_subprocess()
+                )
+            if (
+                "_subprocess_future" not in self.__class__.__dict__
+                or self.__class__._subprocess_future is None
+            ):
+                self.__class__._subprocess_future = self.event_loop.create_task(
+                    self._init_agent_subprocess()
+                )
+            if (
+                "_client_future" not in self.__class__.__dict__
+                or self.__class__._client_future is None
+            ):
+                self.__class__._client_future = self.event_loop.create_task(
+                    self._init_client()
+                )
+
+            self._client_session_future = self.event_loop.create_task(
+                self._init_client_session()
             )
 
-        self._client_session_future = self.event_loop.create_task(
-            self._init_client_session()
-        )
         self._acp_slash_commands = []
         self._acp_modes = []
         self._acp_current_mode_id = None
         self._acp_config_options = []
         self._acp_context_usage = None
         self._acp_session_usage = None
+
+    def check_requirements(self) -> str | None:
+        """Check whether this persona's runtime requirements are met.
+
+        Returns None if the persona is ready to use, or a user-facing error
+        message string describing what is missing.
+
+        Subclasses should override this method to perform their own checks
+        (e.g. verifying that a CLI executable is installed and meets version
+        requirements).
+        """
+        return None
 
     async def before_agent_subprocess(self) -> None:
         """
@@ -484,6 +500,12 @@ class BaseAcpPersona(BasePersona):
 
         This method may be overriden by child classes.
         """
+        # If requirements are not met, inform the user and return early
+        unmet = self.check_requirements()
+        if unmet:
+            self.send_message(f"⚠️ **@{self.defaults.name}** isn't available yet:\n\n{unmet}")
+            return
+
         # If not authenticated, return early
         if not await self.is_authed():
             await self.handle_no_auth(message)

--- a/jupyter_ai_acp_client/extension_app.py
+++ b/jupyter_ai_acp_client/extension_app.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from jupyter_server.extension.application import ExtensionApp
 from .routes import PermissionHandler
+from .telemetry import register_telemetry_schemas, SCHEMA_ID, emit_event
 
 
 class JaiAcpClientExtension(ExtensionApp):
@@ -16,7 +17,7 @@ class JaiAcpClientExtension(ExtensionApp):
 
     def initialize_settings(self):
         """Initialize router settings and register ACP event schema."""
-        from .telemetry import register_telemetry_schemas, SCHEMA_ID
+        
 
         try:
             event_logger = self.serverapp.event_logger
@@ -32,11 +33,103 @@ class JaiAcpClientExtension(ExtensionApp):
                 listener=_log_event,
             )
             self.log.info("Registered ACP event schema and listener with EventLogger.")
+
+            # Defer emit until all extensions are initialized.
+            self.serverapp.io_loop.add_callback(self._emit_agents_status, event_logger)
         except Exception:
             self.log.error(
                 "Failed to register ACP event schema or listener with EventLogger.",
                 exc_info=True,
             )
+
+    def _check_installed_agents(self) -> tuple[list[str], list[str]]:
+        """Import all vendored ACP personas and check their requirements.
+
+        Returns a tuple of (installed, not_installed) persona name lists.
+        """
+        persona_classes = []
+        try:
+            from .acp_personas.claude import ClaudeAcpPersona
+            persona_classes.append(ClaudeAcpPersona)
+        except Exception:
+            pass
+        try:
+            from .acp_personas.kiro import KiroAcpPersona
+            persona_classes.append(KiroAcpPersona)
+        except Exception:
+            pass
+        try:
+            from .acp_personas.codex import CodexAcpPersona
+            persona_classes.append(CodexAcpPersona)
+        except Exception:
+            pass
+        try:
+            from .acp_personas.goose import GooseAcpPersona
+            persona_classes.append(GooseAcpPersona)
+        except Exception:
+            pass
+        try:
+            from .acp_personas.copilot import CopilotAcpPersona
+            persona_classes.append(CopilotAcpPersona)
+        except Exception:
+            pass
+        try:
+            from .acp_personas.mistral_vibe import MistralVibeAcpPersona
+            persona_classes.append(MistralVibeAcpPersona)
+        except Exception:
+            pass
+        try:
+            from .acp_personas.opencode import OpenCodeAcpPersona
+            persona_classes.append(OpenCodeAcpPersona)
+        except Exception:
+            pass
+        try:
+            from .acp_personas.kilo import KiloAcpPersona
+            persona_classes.append(KiloAcpPersona)
+        except Exception:
+            pass
+
+        installed = []
+        not_installed = []
+
+        for cls in persona_classes:
+            try:
+                result = cls.check_requirements(None)
+                name = cls.__name__.replace("AcpPersona", "")
+                if result is None:
+                    installed.append(name)
+                else:
+                    not_installed.append(name)
+            except Exception:
+                name = cls.__name__.replace("AcpPersona", "")
+                not_installed.append(name)
+
+        return installed, not_installed
+
+    def _emit_agents_status(self, event_logger) -> None:
+        """Emit a single acp_agents_status telemetry event at startup."""
+        from .telemetry import emit_event
+
+        installed, not_installed = self._check_installed_agents()
+
+        emit_event(
+            event_logger,
+            "acp_agents_status",
+            "success",
+            {
+                "installed": ", ".join(installed) if installed else "",
+                "not_installed": ", ".join(not_installed) if not_installed else "",
+                "total_registered": str(len(installed) + len(not_installed)),
+            },
+        )
+
+        self.log.info(
+            "ACP agents status: %d installed (%s), %d not installed (%s)",
+            len(installed),
+            ", ".join(installed) or "none",
+            len(not_installed),
+            ", ".join(not_installed) or "none",
+        )
 
     async def stop_extension(self):
         """Clean up router when extension stops."""

--- a/jupyter_ai_acp_client/tests/test_base_acp_persona.py
+++ b/jupyter_ai_acp_client/tests/test_base_acp_persona.py
@@ -21,6 +21,7 @@ def _make_persona(attachments_map: dict | None = None):
     persona.get_client = AsyncMock()
     persona.get_session_id = AsyncMock(return_value="sess-1")
     persona.is_authed = AsyncMock(return_value=True)
+    persona.check_requirements = MagicMock(return_value=None)
     persona._pending_session_recovery_context = False
     persona._was_initially_unauthenticated = False
 

--- a/jupyter_ai_acp_client/tests/test_goose.py
+++ b/jupyter_ai_acp_client/tests/test_goose.py
@@ -4,22 +4,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from acp.exceptions import RequestError
-from jupyter_ai_persona_manager import PersonaRequirementsUnmet
 
-# goose.py has a module-level guard that raises PersonaRequirementsUnmet
-# when the goose CLI is not installed. Mock the guard so we can import
-# helpers in CI without the CLI.
-_mock_run = MagicMock()
-_mock_run.returncode = 0
-_mock_run.stdout = "goose 1.28.0"
-_mock_run.stderr = ""
-
-with patch("shutil.which", return_value="/usr/bin/goose"), \
-     patch("subprocess.run", return_value=_mock_run):
-    from jupyter_ai_acp_client.acp_personas.goose import (
-        _check_goose,
-        _is_setup_error,
-    )
+from jupyter_ai_acp_client.acp_personas.goose import (
+    GooseAcpPersona,
+    _is_setup_error,
+)
 
 
 class TestIsSetupError:
@@ -87,31 +76,34 @@ def _mock_result(stdout="goose 1.28.0", returncode=0, stderr=""):
 
 
 class TestCheckGoose:
-    """Tests for _check_goose() version guard."""
+    """Tests for GooseAcpPersona.check_requirements() version guard."""
 
     def test_not_installed(self):
-        with patch("shutil.which", return_value=None):
-            with pytest.raises(PersonaRequirementsUnmet, match="requires the Goose CLI"):
-                _check_goose()
+        with patch("jupyter_ai_acp_client.acp_personas.goose.shutil.which", return_value=None):
+            result = GooseAcpPersona.check_requirements(None)
+            assert result is not None
+            assert "requires the Goose CLI" in result
 
     def test_valid_version(self):
-        with patch("shutil.which", return_value="/usr/bin/goose"), \
-             patch("subprocess.run", return_value=_mock_result("goose 1.28.0")):
-            _check_goose()  # should not raise
+        with patch("jupyter_ai_acp_client.acp_personas.goose.shutil.which", return_value="/usr/bin/goose"), \
+             patch("jupyter_ai_acp_client.acp_personas.goose.subprocess.run", return_value=_mock_result("goose 1.28.0")):
+            assert GooseAcpPersona.check_requirements(None) is None
 
     def test_old_version(self):
-        with patch("shutil.which", return_value="/usr/bin/goose"), \
-             patch("subprocess.run", return_value=_mock_result("goose 1.7.0")):
-            with pytest.raises(PersonaRequirementsUnmet, match=">=1.8.0"):
-                _check_goose()
+        with patch("jupyter_ai_acp_client.acp_personas.goose.shutil.which", return_value="/usr/bin/goose"), \
+             patch("jupyter_ai_acp_client.acp_personas.goose.subprocess.run", return_value=_mock_result("goose 1.7.0")):
+            result = GooseAcpPersona.check_requirements(None)
+            assert result is not None
+            assert ">=1.8.0" in result
 
     def test_exact_minimum_version(self):
-        with patch("shutil.which", return_value="/usr/bin/goose"), \
-             patch("subprocess.run", return_value=_mock_result("goose 1.8.0")):
-            _check_goose()  # should not raise
+        with patch("jupyter_ai_acp_client.acp_personas.goose.shutil.which", return_value="/usr/bin/goose"), \
+             patch("jupyter_ai_acp_client.acp_personas.goose.subprocess.run", return_value=_mock_result("goose 1.8.0")):
+            assert GooseAcpPersona.check_requirements(None) is None
 
     def test_major_version_2_rejected(self):
-        with patch("shutil.which", return_value="/usr/bin/goose"), \
-             patch("subprocess.run", return_value=_mock_result("goose 2.0.0")):
-            with pytest.raises(PersonaRequirementsUnmet, match=">=1.8.0,<2"):
-                _check_goose()
+        with patch("jupyter_ai_acp_client.acp_personas.goose.shutil.which", return_value="/usr/bin/goose"), \
+             patch("jupyter_ai_acp_client.acp_personas.goose.subprocess.run", return_value=_mock_result("goose 2.0.0")):
+            result = GooseAcpPersona.check_requirements(None)
+            assert result is not None
+            assert ">=1.8.0,<2" in result

--- a/jupyter_ai_acp_client/tests/test_kiro.py
+++ b/jupyter_ai_acp_client/tests/test_kiro.py
@@ -30,14 +30,9 @@ from pycrdt import Awareness
 
 from jupyter_ai_persona_manager import PersonaAwareness
 
-# `kiro.py` runs a `kiro-cli` install/version guard at import time, which raises
-# where kiro-cli isn't installed (e.g. CI). Satisfy the guard with mocks so the
-# persona can be imported and unit-tested without the binary present.
-with patch("shutil.which", return_value="/usr/bin/kiro-cli"), patch(
-    "subprocess.run",
-    return_value=MagicMock(returncode=0, stdout="kiro-cli 2.12.3", stderr=""),
-):
-    from jupyter_ai_acp_client.acp_personas.kiro import KiroAcpPersona
+# `kiro.py` no longer runs module-level guards. The check_requirements()
+# method is called at runtime instead. Import directly without mocks.
+from jupyter_ai_acp_client.acp_personas.kiro import KiroAcpPersona
 from jupyter_ai_acp_client.kiro_client import (
     KiroAcpClient,
     KiroCommand,

--- a/jupyter_ai_acp_client/tests/test_opencode.py
+++ b/jupyter_ai_acp_client/tests/test_opencode.py
@@ -3,23 +3,12 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from jupyter_ai_persona_manager import PersonaRequirementsUnmet
 
-# opencode.py has a module-level guard that raises PersonaRequirementsUnmet
-# when the opencode CLI is not installed. Mock the guard so we can import
-# helpers in CI without the CLI.
-_mock_run = MagicMock()
-_mock_run.returncode = 0
-_mock_run.stdout = "1.0.0"
-_mock_run.stderr = ""
-
-with patch("shutil.which", return_value="/usr/bin/opencode"), \
-     patch("subprocess.run", return_value=_mock_run):
-    from jupyter_ai_acp_client.acp_personas.opencode import (
-        _check_opencode,
-        _has_user_config,
-        _is_auth_error,
-    )
+from jupyter_ai_acp_client.acp_personas.opencode import (
+    OpenCodeAcpPersona,
+    _has_user_config,
+    _is_auth_error,
+)
 
 
 class TestIsAuthError:
@@ -74,17 +63,18 @@ def _mock_result(stdout="1.0.0", returncode=0, stderr=""):
 
 
 class TestCheckOpencode:
-    """Tests for _check_opencode() version guard."""
+    """Tests for OpenCodeAcpPersona.check_requirements() version guard."""
 
     def test_not_installed(self):
-        with patch("shutil.which", return_value=None):
-            with pytest.raises(PersonaRequirementsUnmet, match="requires `opencode`"):
-                _check_opencode()
+        with patch("jupyter_ai_acp_client.acp_personas.opencode.shutil.which", return_value=None):
+            result = OpenCodeAcpPersona.check_requirements(None)
+            assert result is not None
+            assert "requires `opencode`" in result
 
     def test_valid_version(self):
-        with patch("shutil.which", return_value="/usr/bin/opencode"), \
-             patch("subprocess.run", return_value=_mock_result("opencode v1.2.3")):
-            _check_opencode()  # should not raise
+        with patch("jupyter_ai_acp_client.acp_personas.opencode.shutil.which", return_value="/usr/bin/opencode"), \
+             patch("jupyter_ai_acp_client.acp_personas.opencode.subprocess.run", return_value=_mock_result("opencode v1.2.3")):
+            assert OpenCodeAcpPersona.check_requirements(None) is None
 
 
 class TestHasUserConfig:


### PR DESCRIPTION
Move requirement checks from module-level imports to a check_requirements() method on each persona class. This allows all personas to load and be enumerated regardless of whether their requirements are installed.

Added a new `acp_agents_status` telemetry event that reports installed vs not-installed agents at startup.


https://github.com/user-attachments/assets/e01f23f3-0442-4c96-8975-0759e2b7b8fb

