### PR TITLE
Group Dependabot npm security updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    # `schedule.interval` is a REQUIRED key (config fails validation without it),
+    # but it only governs version updates — which are disabled below — so its
+    # value is inert here. Security updates are triggered by Dependabot alerts.
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      npm-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+  - package-ecosystem: "npm"
+    directory: "/ui-tests"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      npm-security-updates-ui-tests:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds `.github/dependabot.yml` to group all Dependabot npm security-update PRs (both root and `/ui-tests`) into a single grouped PR per run, and disables routine version-update PRs (`open-pull-requests-limit: 0`).