### PR TITLE
Add E2E test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,10 +93,18 @@ jobs:
           jupyter labextension list 2>&1 | grep -ie "@jupyter-ai/acp-client.*OK"
           python -m jupyterlab.browser_check --no-browser-test
 
-  integration-tests:
-    name: Integration tests
+  e2e:
+    name: E2E tests
     needs: build
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Renders as "E2E tests (default)", "E2E tests (+JCollab)",
+        # "E2E tests (+JSD)". Each variant maps to a nox session below that
+        # installs the matching transport into an isolated venv.
+        variant: [default, +JCollab, +JSD]
 
     env:
       PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/pw-browsers
@@ -113,42 +121,52 @@ jobs:
       with:
         name: extension-artifacts
 
-    - name: Install the extension
-      run: |
-        set -eux
-        python -m pip install "jupyterlab>=4.0.0,<5" jupyter_ai_acp_client*.whl
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
 
-    - name: Install dependencies
-      working-directory: ui-tests
-      env:
-        YARN_ENABLE_IMMUTABLE_INSTALLS: 0
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-      run: jlpm install
+    - name: Install nox
+      run: uv tool install nox
 
-    - name: Set up browser cache
+    - name: Restore browser cache
       uses: actions/cache@v4
       with:
         path: |
           ${{ github.workspace }}/pw-browsers
         key: ${{ runner.os }}-${{ hashFiles('ui-tests/yarn.lock') }}
 
-    - name: Install browser
+    # Transport-independent, so it runs once at the job level: jlpm needs a
+    # bootstrap jupyterlab, and `playwright install-deps` needs sudo (not
+    # available inside a nox venv). nox reuses this node_modules + browser cache;
+    # the per-transport server deps are installed by nox in the next step.
+    - name: Set up ui-tests deps + browser
+      working-directory: ui-tests
+      env:
+        YARN_ENABLE_IMMUTABLE_INSTALLS: 0
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       run: |
         set -eux
+        python -m pip install "jupyterlab>=4.0.0,<5"
+        jlpm install
         jlpm playwright install-deps
         jlpm playwright install chromium
-      working-directory: ui-tests
 
-    - name: Execute integration tests
-      working-directory: ui-tests
+    - name: Run E2E tests (${{ matrix.variant }})
       run: |
-        jlpm playwright test
+        set -eux
+        case "${{ matrix.variant }}" in
+          default)  SESSION="e2e(env='default')" ;;
+          +JCollab) SESSION="e2e(env='jcollab')" ;;
+          +JSD)     SESSION="e2e(env='jsd')" ;;
+          *) echo "unknown variant: ${{ matrix.variant }}" >&2; exit 1 ;;
+        esac
+        export E2E_WHEEL="$(pwd)/$(ls jupyter_ai_acp_client*.whl)"
+        nox -s "$SESSION"
 
     - name: Upload Playwright Test report
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: jupyter_ai_acp_client-playwright-tests
+        name: jupyter_ai_acp_client-playwright-tests-${{ matrix.variant }}
         path: |
           ui-tests/test-results
           ui-tests/playwright-report

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,58 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""E2E test matrix for jupyter_ai_acp_client.
+
+Runs the Playwright/galata ui-tests suite under three transports so the ACP
+client's chat integration is exercised end-to-end in every supported mode:
+
+    - default   -- RTC-free, WebSocket ``WsChatModel``
+    - jcollab   -- RTC via ``jupyter_collaboration``
+    - jsd       -- RTC via ``jupyter_server_documents``
+
+Each session builds an isolated venv (uv) and installs the extension -- the
+prebuilt wheel via ``E2E_WHEEL`` in CI, or from source locally -- plus the
+transport's packages, then runs the suite. Playwright launches JupyterLab from
+this venv, so the server under test runs the selected transport.
+
+The JS deps and browser binaries are expected to be present in ``ui-tests``
+already (installed once at the CI job level, where ``playwright install-deps``
+can use sudo); the ``jlpm install`` / ``playwright install`` calls below are
+idempotent no-ops on a hit and make local runs self-contained.
+
+Usage::
+
+    nox -l                          # list sessions
+    nox -s e2e                      # all three transports
+    nox -s "e2e(env='jcollab')"     # one transport
+"""
+import os
+
+import nox
+
+# Prefer uv for fast, isolated env creation; fall back to virtualenv.
+nox.options.default_venv_backend = "uv|virtualenv"
+
+# env name -> extra packages that provide the transport.
+#
+# jupyter_collaboration is pinned <5: 5.0.0 shows a "document is taking some
+# time to load" dialog that never clears for .chat documents under slow-load
+# timing, hanging the ui-tests. Same pin as .github/workflows/build.yml. The
+# floors mirror the validated jupyter-ai-router RTC matrix.
+_ENVS = {
+    "default": [],
+    "jcollab": ["jupyter_collaboration>=4,<5"],
+    "jsd": ["jupyter_server_documents"],
+}
+
+
+@nox.session(python="3.10")
+@nox.parametrize("env", list(_ENVS))
+def e2e(session: nox.Session, env: str) -> None:
+    """Run the ui-tests suite against one transport."""
+    # The prebuilt wheel from the CI ``build`` job; from source for local runs.
+    target = os.environ.get("E2E_WHEEL") or "."
+    session.install("jupyterlab>=4.0.0,<5", target, *_ENVS[env])
+    with session.chdir("ui-tests"):
+        session.run("jlpm", "install", external=True)
+        session.run("jlpm", "playwright", "install", "chromium", external=True)
+        session.run("jlpm", "playwright", "test", external=True)


### PR DESCRIPTION
## Motivation

The chat transport underneath the ACP client differs by deployment: RTC-free WebSocket, `jupyter_collaboration`, or `jupyter_server_documents`. The ui-tests only ran under the default (RTC-free) transport, so transport-specific regressions in the client's chat integration went uncaught.

## Summary

The single `Integration tests` job is replaced by three jobs that run the same ui-tests suite under each transport:

- E2E tests (default)
- E2E tests (+JCollab)
- E2E tests (+JSD)

A `noxfile.py` drives the matrix: each session builds an isolated venv (uv, falling back to virtualenv), installs the built wheel plus the transport's packages, and runs the galata suite. Playwright launches JupyterLab from that venv, so the server under test actually runs the selected transport.

## Technical details

This mirrors the matrix added to jupyter-ai-router (#50) and jupyter-ai-persona-manager (#129); the noxfile is essentially the same. `jupyter_collaboration` is pinned `<5` (5.0.0 hangs `.chat` document loads under galata timing).

The job-level step installs the JS deps and browser once (where `playwright install-deps` has sudo); nox reuses that cache and installs only the per-transport server deps in each venv.