### PR TITLE
Migrate to persona-manager set_status/clear_status API

### DIFF
--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -574,7 +574,7 @@ class BaseAcpPersona(BasePersona):
             "Setting %d slash commands for '%s' in room '%s'.",
             len(commands),
             self.name,
-            self.parent.room_id,
+            self.parent.chat.get_id(),
         )
         self._acp_slash_commands = commands
 

--- a/jupyter_ai_acp_client/default_acp_client.py
+++ b/jupyter_ai_acp_client/default_acp_client.py
@@ -274,8 +274,8 @@ class JaiAcpClient(Client):
 
             persona.log.info(f"prompt_and_reply: starting for session {session_id}")
 
-            # Set awareness to indicate writing
-            persona.set_writing_status(True)
+            # Show a status indicator while the persona works
+            persona.set_status()
 
             try:
                 # Build content blocks: text prompt + optional attachment resources
@@ -348,8 +348,8 @@ class JaiAcpClient(Client):
                 persona.log.exception(f"prompt_and_reply: failed for session {session_id}")
                 raise
             finally:
-                # Clear awareness writing state
-                persona.set_writing_status(False)
+                # Clear the status indicator
+                persona.clear_status()
 
     def _handle_agent_message_chunk(self, session_id: str, update: AgentMessageChunk) -> None:
         """Handle an AgentMessageChunk event by appending text to the message."""
@@ -766,8 +766,8 @@ class JaiAcpClient(Client):
             if msg:
                 persona.chat.update_message(msg, append=False, trigger_actions=[find_mentions])
 
-        # Reset awareness
-        persona.set_writing_status(False)
+        # Reset status
+        persona.clear_status()
 
         self._cancel_pending_work(session_id)
 

--- a/jupyter_ai_acp_client/routes.py
+++ b/jupyter_ai_acp_client/routes.py
@@ -30,8 +30,8 @@ class PermissionHandler(APIHandler):
         )
         logger.debug(f"_find_client_for_session: looking for session_id={session_id}, "
                      f"persona_managers count={len(persona_managers)}")
-        for room_id, pm in persona_managers.items():
-            logger.debug(f"  checking room={room_id}, personas={list(pm.personas.keys())}")
+        for chat_id, pm in persona_managers.items():
+            logger.debug(f"  checking chat={chat_id}, personas={list(pm.personas.keys())}")
             for persona_id, persona in pm.personas.items():
                 if not isinstance(persona, BaseAcpPersona):
                     logger.debug(f"    {persona_id}: not BaseAcpPersona, skipping")

--- a/jupyter_ai_acp_client/tests/test_awareness.py
+++ b/jupyter_ai_acp_client/tests/test_awareness.py
@@ -32,7 +32,7 @@ def _state() -> PersonaSessionState:
     round-trip through the real state object."""
     return PersonaSessionState(
         event_logger=None,
-        room_id="test-room",
+        chat_id="test-room",
         persona_id="test-persona",
         log=logging.getLogger("test"),
     )

--- a/jupyter_ai_acp_client/tests/test_default_acp_client.py
+++ b/jupyter_ai_acp_client/tests/test_default_acp_client.py
@@ -265,7 +265,7 @@ def _real_usage_persona():
     # round-trips through the real typed properties.
     persona.state = _state()
     persona.chat = MagicMock()
-    # `set_writing_status()` (called incidentally by `prompt_and_reply`) builds
+    # `set_status()` (called incidentally by `prompt_and_reply`) builds
     # `as_user()`, which reads `self.defaults`; this persona has none, so mock it.
     persona.as_user = MagicMock()
     return persona

--- a/jupyter_ai_acp_client/tests/test_default_acp_client.py
+++ b/jupyter_ai_acp_client/tests/test_default_acp_client.py
@@ -35,7 +35,7 @@ def _state() -> PersonaSessionState:
     round-trip through the real state object."""
     return PersonaSessionState(
         event_logger=None,
-        room_id="test-room",
+        chat_id="test-room",
         persona_id="test-persona",
         log=logging.getLogger("test"),
     )

--- a/jupyter_ai_acp_client/tests/test_kiro.py
+++ b/jupyter_ai_acp_client/tests/test_kiro.py
@@ -71,7 +71,7 @@ def _state(persona_id: str = "test-persona") -> PersonaSessionState:
     round-trip through the real state object."""
     return PersonaSessionState(
         event_logger=None,
-        room_id="test-room",
+        chat_id="test-room",
         persona_id=persona_id,
         log=logging.getLogger("test"),
     )

--- a/jupyter_ai_acp_client/tests/test_tool_call_manager.py
+++ b/jupyter_ai_acp_client/tests/test_tool_call_manager.py
@@ -179,14 +179,14 @@ class TestGetOrCreateTextMessage:
         assert msg_id == "msg-text"
         assert persona.chat.add_message.call_count == 2
 
-    def test_sets_awareness_on_creation(self):
+    def test_sets_status_on_creation(self):
         mgr = ToolCallManager()
         persona = make_persona("msg-1")
         mgr.reset(SESSION_ID)
 
         mgr.get_or_create_text_message(SESSION_ID, persona)
 
-        persona.set_writing_status.assert_called_with("msg-1")
+        persona.set_status.assert_called_with()
 
     def test_does_not_flush_tool_calls_on_creation(self):
         """get_or_create_text_message must not write tool call metadata."""

--- a/jupyter_ai_acp_client/tool_call_manager.py
+++ b/jupyter_ai_acp_client/tool_call_manager.py
@@ -90,7 +90,7 @@ class ToolCallManager:
         session.current_message_id = message_id
         session.all_message_ids.append(message_id)
         persona.log.info(f"Created message {message_id} for session {session_id}")
-        persona.set_writing_status(message_id)
+        persona.set_status()
 
         return message_id
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dependencies = [
     "jupyter_server>=2.4.0,<3",
-    "jupyter_ai_persona_manager>=0.2.0a1",
+    "jupyter_ai_persona_manager>=0.2.0a3",
     "jupyterlab_chat>=0.25.0a1",
     "agent_client_protocol>=0.11.0,<0.12.0",
     "pydantic>=2,<3",


### PR DESCRIPTION
Migrates the ACP client to jupyter-ai-persona-manager's renamed persona status API.

## Context
persona-manager [#133](https://github.com/jupyter-ai-contrib/jupyter-ai-persona-manager/pull/133) replaces the old `set_writing_status(value: bool | str)` with:

- `set_status(status: str = "is typing...")` — show a status indicator, with a caller-settable label.
- `clear_status()` — remove it.

This is a breaking change, so the ACP client's call sites need to move over.

## Changes
- `default_acp_client.py`: `set_writing_status(True)` → `set_status()`; the `prompt_and_reply` `finally` and the cancel path → `clear_status()`.
- `tool_call_manager.py`: `set_writing_status(message_id)` → `set_status()` (the new API doesn't take a message id).
- Updated the two affected unit tests.

## Dependency / CI
Depends on persona-manager #133. Until a persona-manager release that ships `set_status`/`clear_status`, the E2E leg (which installs the released persona-manager) will fail with `AttributeError: set_status`. The unit tests (mock personas) pass. Opening as a draft; will bump the `jupyter_ai_persona_manager` floor and mark ready once the API is released.
