### PR TITLE
Spawn the ACP agent lazily via a prepare() lifecycle hook

### DIFF
--- a/jupyter_ai_acp_client/acp_personas/claude.py
+++ b/jupyter_ai_acp_client/acp_personas/claude.py
@@ -78,7 +78,7 @@ class ClaudeAcpPersona(BaseAcpPersona):
                 raise e
 
 
-    async def handle_no_auth(self, message: Message) -> None:
+    async def handle_no_auth(self, message: Message | None = None) -> None:
         await super().handle_no_auth(message)
         # Claude supports several authentication options so we just send a
         # canned response and let the user choose for themselves.

--- a/jupyter_ai_acp_client/acp_personas/codex.py
+++ b/jupyter_ai_acp_client/acp_personas/codex.py
@@ -48,7 +48,7 @@ class CodexAcpPersona(BaseAcpPersona):
             self.log.info("[Codex] Authentication required: %s", error)
             await self.handle_no_auth(message)
 
-    async def handle_no_auth(self, message: Message) -> None:
+    async def handle_no_auth(self, message: Message | None = None) -> None:
         await super().handle_no_auth(message)
         self.send_message(
             "Codex isn't configured yet."

--- a/jupyter_ai_acp_client/acp_personas/copilot.py
+++ b/jupyter_ai_acp_client/acp_personas/copilot.py
@@ -75,7 +75,7 @@ class CopilotAcpPersona(BaseAcpPersona):
             )
             await self.handle_no_auth(message)
 
-    async def handle_no_auth(self, message: Message) -> None:
+    async def handle_no_auth(self, message: Message | None = None) -> None:
         await super().handle_no_auth(message)
         self.send_message(
             "GitHub Copilot isn't configured yet."

--- a/jupyter_ai_acp_client/acp_personas/goose.py
+++ b/jupyter_ai_acp_client/acp_personas/goose.py
@@ -129,7 +129,7 @@ class GooseAcpPersona(BaseAcpPersona):
             )
             await self.handle_no_auth(message)
 
-    async def handle_no_auth(self, message: Message) -> None:
+    async def handle_no_auth(self, message: Message | None = None) -> None:
         await super().handle_no_auth(message)
         self.send_message(
             "Goose isn't configured yet."

--- a/jupyter_ai_acp_client/acp_personas/kiro.py
+++ b/jupyter_ai_acp_client/acp_personas/kiro.py
@@ -181,7 +181,7 @@ class KiroAcpPersona(BaseAcpPersona):
             return True
         return await self._check_kiro_auth()
     
-    async def handle_no_auth(self, message: Message) -> None:
+    async def handle_no_auth(self, message: Message | None = None) -> None:
         await super().handle_no_auth(message)
 
         # Determine which command to show

--- a/jupyter_ai_acp_client/acp_personas/kiro.py
+++ b/jupyter_ai_acp_client/acp_personas/kiro.py
@@ -175,11 +175,11 @@ class KiroAcpPersona(BaseAcpPersona):
         self.log.info("[Kiro] User is signed in.")
     
     async def is_authed(self) -> bool:
-        # In Kiro, the user remains signed in even if they sign out while the
-        # ACP agent server is running. Therefore we can just return the status
-        # of the `before_agent_subprocess()` task to check if the user is
-        # authenticated.
-        return self._before_subprocess_future.done()
+        # Trust a settled auth gate, else one-shot check so signed-in users aren't reprompted.
+        fut = self.__class__._before_subprocess_future
+        if fut is not None and fut.done():
+            return True
+        return await self._check_kiro_auth()
     
     async def handle_no_auth(self, message: Message) -> None:
         await super().handle_no_auth(message)

--- a/jupyter_ai_acp_client/acp_personas/mistral_vibe.py
+++ b/jupyter_ai_acp_client/acp_personas/mistral_vibe.py
@@ -72,7 +72,7 @@ class MistralVibeAcpPersona(BaseAcpPersona):
             )
             await self.handle_no_auth(message)
 
-    async def handle_no_auth(self, message: Message) -> None:
+    async def handle_no_auth(self, message: Message | None = None) -> None:
         await super().handle_no_auth(message)
         self.send_message(
             "Mistral Vibe isn't configured yet."

--- a/jupyter_ai_acp_client/acp_personas/opencode.py
+++ b/jupyter_ai_acp_client/acp_personas/opencode.py
@@ -145,7 +145,7 @@ class OpenCodeAcpPersona(BaseAcpPersona):
             )
             await self.handle_no_auth(message)
 
-    async def handle_no_auth(self, message: Message) -> None:
+    async def handle_no_auth(self, message: Message | None = None) -> None:
         await super().handle_no_auth(message)
         self.send_message(
             "OpenCode isn't configured yet."

--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -64,6 +64,12 @@ def _flatten_select_options(options) -> list:
     return flat
 
 
+class _NotAuthenticated(Exception):
+    """Raised by `prepare()` when the user is not signed in, so the manager
+    re-runs `prepare()` on the next message. `handle_uncaught_exception` turns
+    it into a login prompt instead of a generic error."""
+
+
 class BaseAcpPersona(BasePersona):
     _before_subprocess_future: ClassVar[Task[None] | None] = None
     """
@@ -162,9 +168,7 @@ class BaseAcpPersona(BasePersona):
         self._executable = executable
         self._pending_session_recovery_context: bool = False
         self._was_initially_unauthenticated: bool = False
-        self._engagement_emitted: bool = False
-        self._login_emitted: bool = False
-        self._success_emitted: bool = False
+        self._emitted: set[str] = set()
         self._client_session_future: Task[
             NewSessionResponse | LoadSessionResponse
         ] | None = None
@@ -175,13 +179,23 @@ class BaseAcpPersona(BasePersona):
         self._acp_context_usage = None
         self._acp_session_usage = None
 
-        # Agent's requirements are met
+        self.emit_once("acp_requirements_met")
+
+    def emit(self, operation: str, outcome: str = "success") -> None:
+        """Emit a funnel event."""
         emit_event(
             self.event_logger,
-            "acp_requirements_met",
-            "success",
+            operation,
+            outcome,
             {"persona_class": self.__class__.__name__},
         )
+
+    def emit_once(self, operation: str, outcome: str = "success") -> None:
+        """Emit a funnel event at most once per persona instance."""
+        if operation in self._emitted:
+            return
+        self._emitted.add(operation)
+        self.emit(operation, outcome)
 
     async def before_agent_subprocess(self) -> None:
         """
@@ -388,28 +402,27 @@ class BaseAcpPersona(BasePersona):
 
     async def prepare(self) -> None:
         """
-        ACP startup: spawn the shared agent subprocess/client and create this
-        chat's session. The manager runs this once via `BasePersona`, which
-        also handles awaiting an in-flight run for concurrent messages and
-        retrying a failed one — so this just does the work.
+        ACP startup: gate on auth, then spawn the shared agent subprocess/client
+        and create this chat's session. The manager runs this once via
+        `BasePersona`, awaiting an in-flight run for concurrent messages and
+        re-running it after a failed one.
 
-        The startup tasks are kicked off but not awaited to readiness, so an
-        auth-gated persona (e.g. Kiro) is not blocked before its login prompt.
-        A class-level startup task that previously failed (e.g. a subprocess
-        spawn error) is discarded here so a fresh persona instance recreates it.
+        If the user is not authenticated, raise `_NotAuthenticated` so the
+        manager re-runs this on the next message (retrying login each time). The
+        login prompt is shown from `handle_uncaught_exception`. A class-level
+        startup task that previously failed is discarded here so a fresh persona
+        instance recreates it.
         """
         # Reset class-level startup tasks that failed so the checks below.
         self._discard_failed_startup()
 
-        # Emit 'engagement' once per persona instance.
-        if not self._engagement_emitted:
-            self._engagement_emitted = True
-            emit_event(
-                self.event_logger,
-                "acp_engagement",
-                "success",
-                {"persona_class": self.__class__.__name__},
-            )
+        self.emit_once("acp_engagement")
+
+        if not await self.is_authed():
+            self.emit("acp_login", "failure")
+            raise _NotAuthenticated()
+
+        self.emit_once("acp_login")
 
         cls = self.__class__
         if (
@@ -429,6 +442,18 @@ class BaseAcpPersona(BasePersona):
             self._client_session_future = self.event_loop.create_task(
                 self._init_client_session()
             )
+
+        # Await startup to readiness so success/failure reflects the real
+        # outcome. 
+        try:
+            await self.get_agent_subprocess()
+            await self.get_client()
+            await self.get_session_response()
+        except Exception:
+            self.emit("acp_success", "failure")
+            raise
+
+        self.emit_once("acp_success")
 
     def _discard_failed_startup(self) -> None:
         """
@@ -489,20 +514,24 @@ class BaseAcpPersona(BasePersona):
         """
         return True
 
-    async def handle_no_auth(self, message: Message) -> None:
+    async def handle_no_auth(self, message: Message | None = None) -> None:
         """
-        Method called when the persona receives a message while the user is not
-        authenticated. Sets the `_was_initially_unauthenticated` flag so the
-        agent can proactively resume the user's request after signing in.
-
-        Subclasses should call `await super().handle_no_auth(message)` first,
-        then send a custom message asking the user to log in and perform any
-        additional setup (e.g. opening a login terminal).
+        Ask the user to sign in. Sets `_was_initially_unauthenticated` so the
+        agent can resume the request after sign-in. Subclasses override to send
+        the sign-in instructions and open a login terminal.
         """
         self._was_initially_unauthenticated = True
         self.log.warning(
             "[%s] Received message while unauthenticated.", self.__class__.__name__
         )
+
+    async def handle_uncaught_exception(self, exc: Exception) -> None:
+        """Show the login prompt for an auth failure from `prepare()`; otherwise
+        fall back to the default error handling."""
+        if isinstance(exc, _NotAuthenticated):
+            await self.handle_no_auth(None)
+            return
+        await super().handle_uncaught_exception(exc)
 
     def _build_history_context(
         self,
@@ -545,21 +574,7 @@ class BaseAcpPersona(BasePersona):
 
         This method may be overriden by child classes.
         """
-        # If not authenticated, return early
-        if not await self.is_authed():
-            await self.handle_no_auth(message)
-            return
-
-        # User is authenticated for this persona.
-        if not self._login_emitted:
-            self._login_emitted = True
-            emit_event(
-                self.event_logger,
-                "acp_login",
-                "success",
-                {"persona_class": self.__class__.__name__},
-            )
-
+        # Auth is gated in prepare(); reaching here means the user is signed in.
         # If the user was previously unauthenticated, proactively resume their
         # original request instead of processing this message normally.
         if self._was_initially_unauthenticated:
@@ -604,15 +619,6 @@ class BaseAcpPersona(BasePersona):
             attachments=attachments,
             root_dir=self.parent.root_dir,
         )
-
-        if not self._success_emitted:
-            self._success_emitted = True
-            emit_event(
-                self.event_logger,
-                "acp_success",
-                "success",
-                {"persona_class": self.__class__.__name__},
-            )
 
     async def cancel_response(self) -> None:
         """

--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -162,40 +162,26 @@ class BaseAcpPersona(BasePersona):
         self._executable = executable
         self._pending_session_recovery_context: bool = False
         self._was_initially_unauthenticated: bool = False
-
-        # Ensure each subclass has its own subprocess and client by checking if the
-        # class variable is defined directly on this class (not inherited)
-        if (
-            "_before_subprocess_future" not in self.__class__.__dict__
-            or self.__class__._before_subprocess_future is None
-        ):
-            self.__class__._before_subprocess_future = self.event_loop.create_task(
-                self.before_agent_subprocess()
-            )
-        if (
-            "_subprocess_future" not in self.__class__.__dict__
-            or self.__class__._subprocess_future is None
-        ):
-            self.__class__._subprocess_future = self.event_loop.create_task(
-                self._init_agent_subprocess()
-            )
-        if (
-            "_client_future" not in self.__class__.__dict__
-            or self.__class__._client_future is None
-        ):
-            self.__class__._client_future = self.event_loop.create_task(
-                self._init_client()
-            )
-
-        self._client_session_future = self.event_loop.create_task(
-            self._init_client_session()
-        )
+        self._engagement_emitted: bool = False
+        self._login_emitted: bool = False
+        self._success_emitted: bool = False
+        self._client_session_future: Task[
+            NewSessionResponse | LoadSessionResponse
+        ] | None = None
         self._acp_slash_commands = []
         self._acp_modes = []
         self._acp_current_mode_id = None
         self._acp_config_options = []
         self._acp_context_usage = None
         self._acp_session_usage = None
+
+        # Agent's requirements are met
+        emit_event(
+            self.event_logger,
+            "acp_requirements_met",
+            "success",
+            {"persona_class": self.__class__.__name__},
+        )
 
     async def before_agent_subprocess(self) -> None:
         """
@@ -392,22 +378,97 @@ class BaseAcpPersona(BasePersona):
             root_dir=self.parent.root_dir,
         )
 
+    def _client_started(self) -> bool:
+        """
+        Whether `prepare()` has created the client task.
+        Does not create it, so callers can probe without spawning.
+        """
+        cls = self.__class__
+        return "_client_future" in cls.__dict__ and cls._client_future is not None
+
+    async def prepare(self) -> None:
+        """
+        ACP startup: spawn the shared agent subprocess/client and create this
+        chat's session. The manager runs this once via `BasePersona`, which
+        also handles awaiting an in-flight run for concurrent messages and
+        retrying a failed one — so this just does the work.
+
+        The startup tasks are kicked off but not awaited to readiness, so an
+        auth-gated persona (e.g. Kiro) is not blocked before its login prompt.
+        A class-level startup task that previously failed (e.g. a subprocess
+        spawn error) is discarded here so a fresh persona instance recreates it.
+        """
+        # Reset class-level startup tasks that failed so the checks below.
+        self._discard_failed_startup()
+
+        # Emit 'engagement' once per persona instance.
+        if not self._engagement_emitted:
+            self._engagement_emitted = True
+            emit_event(
+                self.event_logger,
+                "acp_engagement",
+                "success",
+                {"persona_class": self.__class__.__name__},
+            )
+
+        cls = self.__class__
+        if (
+            "_before_subprocess_future" not in cls.__dict__
+            or cls._before_subprocess_future is None
+        ):
+            cls._before_subprocess_future = self.event_loop.create_task(
+                self.before_agent_subprocess()
+            )
+        if "_subprocess_future" not in cls.__dict__ or cls._subprocess_future is None:
+            cls._subprocess_future = self.event_loop.create_task(
+                self._init_agent_subprocess()
+            )
+        if "_client_future" not in cls.__dict__ or cls._client_future is None:
+            cls._client_future = self.event_loop.create_task(self._init_client())
+        if self._client_session_future is None:
+            self._client_session_future = self.event_loop.create_task(
+                self._init_client_session()
+            )
+
+    def _discard_failed_startup(self) -> None:
+        """
+        Drop the shared (class-level) startup tasks that completed with an
+        exception so `prepare()` recreates them. Tasks still running or
+        completed successfully are left untouched. This is what lets a fresh
+        persona instance recover a subprocess/client that failed to start.
+        """
+        cls = self.__class__
+        for name in (
+            "_before_subprocess_future",
+            "_subprocess_future",
+            "_client_future",
+        ):
+            if self._is_discardable(cls.__dict__.get(name)):
+                setattr(cls, name, None)
+        if self._is_discardable(self._client_session_future):
+            self._client_session_future = None
+
+    @staticmethod
+    def _is_discardable(fut: object) -> bool:
+        """A startup task that ended without success — cancelled or raised — so
+        `prepare()` should recreate it. `.exception()` is guarded by the
+        short-circuit since it raises on a cancelled task."""
+        return (
+            isinstance(fut, Task)
+            and fut.done()
+            and (fut.cancelled() or fut.exception() is not None)
+        )
+
     async def get_agent_subprocess(self) -> asyncio.subprocess.Process:
-        """
-        Safely returns the ACP agent subprocess for this persona.
-        """
+        """Safely returns the ACP agent subprocess (spawned by `prepare()`)."""
         return await self.__class__._subprocess_future
 
     async def get_client(self) -> JaiAcpClient:
-        """
-        Safely returns the ACP client for this persona.
-        """
+        """Safely returns the ACP client (initialized by `prepare()`)."""
         return await self.__class__._client_future
 
     async def get_session_response(self) -> NewSessionResponse | LoadSessionResponse:
-        """
-        Safely returns the ACP session response for this chat.
-        """
+        """Safely returns the ACP session response (created by `prepare()`)."""
         return await self._client_session_future
 
     async def get_session_id(self) -> str:
@@ -489,6 +550,16 @@ class BaseAcpPersona(BasePersona):
             await self.handle_no_auth(message)
             return
 
+        # User is authenticated for this persona.
+        if not self._login_emitted:
+            self._login_emitted = True
+            emit_event(
+                self.event_logger,
+                "acp_login",
+                "success",
+                {"persona_class": self.__class__.__name__},
+            )
+
         # If the user was previously unauthenticated, proactively resume their
         # original request instead of processing this message normally.
         if self._was_initially_unauthenticated:
@@ -534,6 +605,15 @@ class BaseAcpPersona(BasePersona):
             root_dir=self.parent.root_dir,
         )
 
+        if not self._success_emitted:
+            self._success_emitted = True
+            emit_event(
+                self.event_logger,
+                "acp_success",
+                "success",
+                {"persona_class": self.__class__.__name__},
+            )
+
     async def cancel_response(self) -> None:
         """
         Interrupt this persona's in-progress ACP turn.
@@ -548,6 +628,9 @@ class BaseAcpPersona(BasePersona):
         ongoing prompt turn — always has a turn to cancel. A not-yet-initialized
         session is still ignored defensively.
         """
+        # Nothing to cancel if the persona was never prepared (no session yet).
+        if self._client_session_future is None:
+            return
         try:
             session_id = await self.get_session_id()
         except (AssertionError, KeyError):
@@ -1008,6 +1091,23 @@ class BaseAcpPersona(BasePersona):
     async def _shutdown(self):
         self.log.info("[shutdown] Starting for '%s'.", self.__class__.__name__)
 
+        if not self._client_started():
+            before_future = self.__class__._before_subprocess_future
+            if isinstance(before_future, Task) and not before_future.done():
+                before_future.cancel()
+            if isinstance(self._client_session_future, Task) and not (
+                self._client_session_future.done()
+            ):
+                self._client_session_future.cancel()
+            self.__class__._before_subprocess_future = None
+            self.__class__._subprocess_future = None
+            self.__class__._client_future = None
+            self.log.info(
+                "[shutdown] Persona '%s' was never engaged; nothing to tear down.",
+                self.__class__.__name__,
+            )
+            return
+
         # Cancel any pending startup futures to avoid hanging on auth-gated
         # personas (e.g. Kiro) that never finished startup.
         for future in [
@@ -1022,12 +1122,14 @@ class BaseAcpPersona(BasePersona):
         # Step 1: Session cleanup
         try:
             client = await self.get_client()
-            session_id = await self.get_session_id()
-            await client.end_session(session_id)
-            self.log.info(
-                "[shutdown] Step 1: session ended for '%s'.",
-                self.__class__.__name__,
-            )
+            # Only end a session that exists.
+            if self._client_session_future is not None:
+                session_id = await self.get_session_id()
+                await client.end_session(session_id)
+                self.log.info(
+                    "[shutdown] Step 1: session ended for '%s'.",
+                    self.__class__.__name__,
+                )
         except asyncio.CancelledError:
             pass
         except Exception:

--- a/jupyter_ai_acp_client/routes.py
+++ b/jupyter_ai_acp_client/routes.py
@@ -36,6 +36,10 @@ class PermissionHandler(APIHandler):
                 if not isinstance(persona, BaseAcpPersona):
                     logger.debug(f"    {persona_id}: not BaseAcpPersona, skipping")
                     continue
+                # Never-engaged: personas have no client 
+                if not persona._client_started():
+                    logger.debug(f"    {persona_id}: client not started, skipping")
+                    continue
                 client = await persona.get_client()
                 if client.includes_session(session_id):
                     logger.debug(f"    FOUND client for session {session_id}")

--- a/jupyter_ai_acp_client/tests/test_base_acp_persona.py
+++ b/jupyter_ai_acp_client/tests/test_base_acp_persona.py
@@ -1,5 +1,6 @@
 """Tests for attachment resolution and load-session recovery in BaseAcpPersona."""
 
+import asyncio
 import logging
 from unittest.mock import AsyncMock, MagicMock
 
@@ -21,6 +22,7 @@ def _make_persona(attachments_map: dict | None = None):
     persona.get_client = AsyncMock()
     persona.get_session_id = AsyncMock(return_value="sess-1")
     persona.is_authed = AsyncMock(return_value=True)
+    persona.prepare = AsyncMock()
     persona._pending_session_recovery_context = False
     persona._was_initially_unauthenticated = False
 
@@ -504,3 +506,314 @@ class TestHandleUncaughtException:
         if persona.send_message.called:
             body = persona.send_message.call_args[0][0]
             assert "**Error code:**" not in body
+
+
+def _make_lazy_persona(persona_cls=None, subprocess_impl=None):
+    """
+    Build a BaseAcpPersona subclass instance without running the heavy
+    BasePersona.__init__, wired just enough to exercise `prepare()`, the
+    non-spawning `_client_started` probe, and the shutdown guard.
+
+    By default each call defines a fresh subclass so class-level futures don't
+    leak between tests. Pass `persona_cls` to build a second instance that
+    shares one class's futures (for concurrency tests). Pass `subprocess_impl`
+    to inject a counting/failing agent-subprocess stub. Nothing real is spawned.
+    """
+
+    if persona_cls is None:
+        class _LazyTestPersona(BaseAcpPersona):
+            # Shadow the read-only BasePersona properties so the test can inject
+            # them without running the real constructor.
+            event_loop = None
+            event_logger = None
+
+            @property
+            def defaults(self):
+                return MagicMock()
+
+        persona_cls = _LazyTestPersona
+
+    persona = persona_cls.__new__(persona_cls)
+    persona.event_loop = asyncio.get_event_loop()
+    persona.log = logging.getLogger("lazy-test-persona")
+    persona._client_session_future = None
+    persona._prepare_task = None
+    persona._engagement_emitted = False
+    persona.event_logger = MagicMock()
+
+    async def _fake_subprocess():
+        return "subprocess"
+
+    async def _fake_client():
+        return "client"
+
+    async def _fake_session():
+        return "session"
+
+    persona._init_agent_subprocess = subprocess_impl or _fake_subprocess
+    persona._init_client = _fake_client
+    persona._init_client_session = _fake_session
+    return persona_cls, persona
+
+
+class TestPrepareLifecycle:
+    """
+    Deferred-spawn behavior for issue #172: construction spawns nothing; the
+    `prepare()` hook performs the startup once, before the first message.
+    """
+
+    async def test_construction_creates_no_futures(self):
+        """A freshly constructed persona has spawned nothing."""
+        cls, persona = _make_lazy_persona()
+        assert "_subprocess_future" not in cls.__dict__
+        assert "_client_future" not in cls.__dict__
+        assert persona._client_session_future is None
+        assert persona._client_started() is False
+
+    async def test_prepare_starts_subprocess_client_and_session(self):
+        """prepare() creates the subprocess, client, and session futures."""
+        cls, persona = _make_lazy_persona()
+        assert persona._client_started() is False
+
+        await persona.prepare()
+
+        assert cls._subprocess_future is not None
+        assert cls._client_future is not None
+        assert persona._client_session_future is not None
+        assert persona._client_started() is True
+        # The futures resolve to the stubbed startup results.
+        assert await persona.get_agent_subprocess() == "subprocess"
+        assert await persona.get_client() == "client"
+        assert await persona.get_session_response() == "session"
+
+    async def test_prepare_is_idempotent(self):
+        """Calling prepare() twice does not recreate the futures or re-emit."""
+        cls, persona = _make_lazy_persona()
+
+        await persona.prepare()
+        subprocess_future = cls._subprocess_future
+        client_future = cls._client_future
+        session_future = persona._client_session_future
+
+        await persona.prepare()
+
+        assert cls._subprocess_future is subprocess_future
+        assert cls._client_future is client_future
+        assert persona._client_session_future is session_future
+        ops = [
+            c.kwargs.get("data", {}).get("operation")
+            for c in persona.event_logger.emit.call_args_list
+        ]
+        assert ops.count("acp_engagement") == 1
+
+    async def test_prepare_emits_engagement(self):
+        """prepare() emits the 'tried' engagement funnel event."""
+        cls, persona = _make_lazy_persona()
+
+        await persona.prepare()
+
+        ops = [
+            c.kwargs.get("data", {}).get("operation")
+            for c in persona.event_logger.emit.call_args_list
+        ]
+        assert "acp_engagement" in ops
+
+    async def test_shutdown_of_unengaged_persona_does_not_spawn(self):
+        """
+        Shutting down a persona that was never engaged must not spawn it.
+        `_shutdown` must not call get_client()/get_agent_subprocess() in this
+        path, and must reset the class futures.
+        """
+        cls, persona = _make_lazy_persona()
+        cls._before_subprocess_future = None
+        persona.get_client = AsyncMock()
+        persona.get_agent_subprocess = AsyncMock()
+        persona.get_session_id = AsyncMock()
+
+        await persona._shutdown()
+
+        persona.get_client.assert_not_awaited()
+        persona.get_agent_subprocess.assert_not_awaited()
+        persona.get_session_id.assert_not_awaited()
+        assert cls._client_future is None
+        assert cls._subprocess_future is None
+
+
+class TestPrepareConcurrencyAndRetry:
+    """
+    Hardening for prepare(): idempotent under concurrency, exactly one shared
+    subprocess across instances of the same class, exception propagation, and
+    retry after a failed startup.
+    """
+
+    async def test_concurrent_prepare_spawns_one_subprocess(self):
+        """Many concurrent prepare() calls on one instance = one subprocess,
+        one engagement event."""
+        calls = []
+
+        async def counting_subprocess():
+            calls.append(1)
+            return "subprocess"
+
+        cls, persona = _make_lazy_persona(subprocess_impl=counting_subprocess)
+
+        await asyncio.gather(*[persona.prepare() for _ in range(5)])
+        # Let the (single) subprocess task actually run.
+        await persona.get_agent_subprocess()
+
+        assert sum(calls) == 1
+        ops = [
+            c.kwargs.get("data", {}).get("operation")
+            for c in persona.event_logger.emit.call_args_list
+        ]
+        assert ops.count("acp_engagement") == 1
+
+    async def test_two_instances_same_class_share_one_subprocess(self):
+        """Two personas of the same class preparing at once spawn exactly one
+        shared agent subprocess."""
+        calls = []
+
+        async def counting_subprocess():
+            calls.append(1)
+            return "subprocess"
+
+        cls, p1 = _make_lazy_persona(subprocess_impl=counting_subprocess)
+        _, p2 = _make_lazy_persona(persona_cls=cls, subprocess_impl=counting_subprocess)
+
+        await asyncio.gather(p1.prepare(), p2.prepare())
+        # Both instances resolve the same shared subprocess.
+        s1 = await p1.get_agent_subprocess()
+        s2 = await p2.get_agent_subprocess()
+
+        assert sum(calls) == 1
+        assert s1 == s2 == "subprocess"
+        assert p1.__class__._subprocess_future is p2.__class__._subprocess_future
+
+    async def test_failed_startup_is_retried_on_next_prepare(self):
+        """A subprocess that failed is discarded and retried on the next
+        prepare()."""
+        state = {"fail": True, "calls": 0}
+
+        async def flaky_subprocess():
+            state["calls"] += 1
+            if state["fail"]:
+                raise RuntimeError("spawn boom")
+            return "subprocess"
+
+        cls, persona = _make_lazy_persona(subprocess_impl=flaky_subprocess)
+
+        # First attempt fails; the failure surfaces when the subprocess is awaited.
+        await persona.prepare()
+        with pytest.raises(RuntimeError, match="spawn boom"):
+            await persona.get_agent_subprocess()
+
+        # Clear the fault and prepare again: the failed task is discarded and recreated.
+        state["fail"] = False
+        await persona.prepare()
+        assert await persona.get_agent_subprocess() == "subprocess"
+        assert state["calls"] == 2  # retried, not cached-failed
+
+    async def test_cancelled_startup_is_discarded_on_next_prepare(self):
+        """A cancelled startup task is discarded and recreated on the next
+        prepare() (a cancelled future is a not-succeeded future)."""
+        cls, persona = _make_lazy_persona()
+        await persona.prepare()
+
+        # Cancel the shared subprocess task and let the cancellation settle.
+        cls._subprocess_future.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await cls._subprocess_future
+
+        # Next prepare() must drop the cancelled task and create a live one.
+        await persona.prepare()
+        assert await persona.get_agent_subprocess() == "subprocess"
+
+    async def test_engagement_re_emits_only_after_reset(self):
+        """A successful prepare() emits engagement once even across retries of a
+        failed startup (engagement is per-instance, emitted on first call)."""
+        cls, persona = _make_lazy_persona()
+        await persona.prepare()
+        await persona.prepare()
+        ops = [
+            c.kwargs.get("data", {}).get("operation")
+            for c in persona.event_logger.emit.call_args_list
+        ]
+        assert ops.count("acp_engagement") == 1
+
+
+class TestProcessMessagePropagatesStartupFailure:
+    """A startup failure reaches process_message so the manager can show it."""
+
+    async def test_get_client_failure_propagates(self):
+        persona = _make_persona()  # persona.prepare is an AsyncMock no-op
+        persona.get_client = AsyncMock(side_effect=RuntimeError("client boom"))
+
+        with pytest.raises(RuntimeError, match="client boom"):
+            await BaseAcpPersona.process_message(persona, _make_message("@bot hi"))
+
+
+class TestFunnelEvents:
+    """Telemetry funnel: requirements_met (construction) -> engagement (prepare)
+    -> login + usage (process_message)."""
+
+    def test_requirements_met_emitted_on_construction(self, monkeypatch):
+        import jupyter_ai_acp_client.base_acp_persona as mod
+
+        emitted = []
+        monkeypatch.setattr(
+            mod,
+            "emit_event",
+            lambda logger, op, outcome, details=None: emitted.append(op),
+        )
+        # Stub the heavy BasePersona.__init__ so we can exercise BaseAcpPersona's.
+        monkeypatch.setattr(mod.BasePersona, "__init__", lambda self, *a, **k: None)
+
+        class _P(BaseAcpPersona):
+            event_loop = None
+            event_logger = None
+
+            @property
+            def defaults(self):
+                return MagicMock()
+
+        p = _P.__new__(_P)
+        BaseAcpPersona.__init__(p, executable=["x"])
+
+        assert "acp_requirements_met" in emitted
+
+    async def test_login_and_success_emitted_on_successful_message(self):
+        client = _make_client()
+        persona = _make_persona()
+        persona.get_client.return_value = client
+        persona.event_logger = MagicMock()
+        persona._login_emitted = False
+        persona._success_emitted = False
+
+        await BaseAcpPersona.process_message(persona, _make_message("@bot hi"))
+
+        ops = [
+            c.kwargs.get("data", {}).get("operation")
+            for c in persona.event_logger.emit.call_args_list
+        ]
+        assert "acp_login" in ops
+        assert "acp_success" in ops
+
+    async def test_no_login_or_success_when_unauthenticated(self):
+        persona = _make_persona()
+        persona.is_authed = AsyncMock(return_value=False)
+        persona.handle_no_auth = AsyncMock()
+        persona.event_logger = MagicMock()
+        persona._login_emitted = False
+        persona._success_emitted = False
+
+        await BaseAcpPersona.process_message(persona, _make_message("@bot hi"))
+
+        ops = [
+            c.kwargs.get("data", {}).get("operation")
+            for c in persona.event_logger.emit.call_args_list
+        ]
+        assert "acp_login" not in ops
+        assert "acp_success" not in ops
+
+
+

--- a/jupyter_ai_acp_client/tests/test_base_acp_persona.py
+++ b/jupyter_ai_acp_client/tests/test_base_acp_persona.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from jupyterlab_chat.models import Message
 
-from jupyter_ai_acp_client.base_acp_persona import BaseAcpPersona
+from jupyter_ai_acp_client.base_acp_persona import BaseAcpPersona, _NotAuthenticated
 
 
 def _make_chat_message(
@@ -538,7 +538,8 @@ def _make_lazy_persona(persona_cls=None, subprocess_impl=None):
     persona.log = logging.getLogger("lazy-test-persona")
     persona._client_session_future = None
     persona._prepare_task = None
-    persona._engagement_emitted = False
+    persona._emitted = set()
+    persona.is_authed = AsyncMock(return_value=True)
     persona.event_logger = MagicMock()
 
     async def _fake_subprocess():
@@ -702,10 +703,9 @@ class TestPrepareConcurrencyAndRetry:
 
         cls, persona = _make_lazy_persona(subprocess_impl=flaky_subprocess)
 
-        # First attempt fails; the failure surfaces when the subprocess is awaited.
-        await persona.prepare()
+        # prepare() awaits startup, so the spawn failure propagates out of it.
         with pytest.raises(RuntimeError, match="spawn boom"):
-            await persona.get_agent_subprocess()
+            await persona.prepare()
 
         # Clear the fault and prepare again: the failed task is discarded and recreated.
         state["fail"] = False
@@ -717,14 +717,18 @@ class TestPrepareConcurrencyAndRetry:
         """A cancelled startup task is discarded and recreated on the next
         prepare() (a cancelled future is a not-succeeded future)."""
         cls, persona = _make_lazy_persona()
-        await persona.prepare()
 
-        # Cancel the shared subprocess task and let the cancellation settle.
-        cls._subprocess_future.cancel()
+        # Seed a previously-cancelled shared subprocess task on the class.
+        async def _never():
+            await asyncio.sleep(3600)
+
+        stuck = persona.event_loop.create_task(_never())
+        stuck.cancel()
         with pytest.raises(asyncio.CancelledError):
-            await cls._subprocess_future
+            await stuck
+        cls._subprocess_future = stuck
 
-        # Next prepare() must drop the cancelled task and create a live one.
+        # prepare() must discard the cancelled task and create a live one.
         await persona.prepare()
         assert await persona.get_agent_subprocess() == "subprocess"
 
@@ -753,7 +757,7 @@ class TestProcessMessagePropagatesStartupFailure:
 
 
 class TestFunnelEvents:
-    """Telemetry funnel: requirements_met (construction) -> engagement (prepare)
+    """Event funnel: requirements_met (construction) -> engagement (prepare)
     -> login + usage (process_message)."""
 
     def test_requirements_met_emitted_on_construction(self, monkeypatch):
@@ -781,15 +785,10 @@ class TestFunnelEvents:
 
         assert "acp_requirements_met" in emitted
 
-    async def test_login_and_success_emitted_on_successful_message(self):
-        client = _make_client()
-        persona = _make_persona()
-        persona.get_client.return_value = client
-        persona.event_logger = MagicMock()
-        persona._login_emitted = False
-        persona._success_emitted = False
+    async def test_login_and_success_emitted_on_successful_prepare(self):
+        cls, persona = _make_lazy_persona()
 
-        await BaseAcpPersona.process_message(persona, _make_message("@bot hi"))
+        await persona.prepare()
 
         ops = [
             c.kwargs.get("data", {}).get("operation")
@@ -798,22 +797,23 @@ class TestFunnelEvents:
         assert "acp_login" in ops
         assert "acp_success" in ops
 
-    async def test_no_login_or_success_when_unauthenticated(self):
-        persona = _make_persona()
+    async def test_login_failure_and_no_success_when_unauthenticated(self):
+        cls, persona = _make_lazy_persona()
         persona.is_authed = AsyncMock(return_value=False)
-        persona.handle_no_auth = AsyncMock()
-        persona.event_logger = MagicMock()
-        persona._login_emitted = False
-        persona._success_emitted = False
 
-        await BaseAcpPersona.process_message(persona, _make_message("@bot hi"))
+        with pytest.raises(_NotAuthenticated):
+            await persona.prepare()
 
-        ops = [
-            c.kwargs.get("data", {}).get("operation")
+        calls = [
+            (
+                c.kwargs.get("data", {}).get("operation"),
+                c.kwargs.get("data", {}).get("outcome"),
+            )
             for c in persona.event_logger.emit.call_args_list
         ]
-        assert "acp_login" not in ops
-        assert "acp_success" not in ops
+        assert ("acp_login", "failure") in calls
+        assert ("acp_login", "success") not in calls
+        assert ("acp_success", "success") not in calls
 
 
 


### PR DESCRIPTION
Opening a chat used to construct every ACP persona eagerly, and each constructor launched its agent subprocess. So idle personas held large resident processes before the user ever messaged them ([issue #172](https://github.com/jupyter-ai-contrib/jupyter-ai-acp-client/issues/172)).
  
Fix: Move startup out of __init__ into a prepare() hook that the persona manager runs once, on first use.
Depends on https://github.com/jupyter-ai-contrib/jupyter-ai-persona-manager/pull/136