### PR TITLE
prepare() waits for login in instead of fast-failing

### DIFF
--- a/jupyter_ai_acp_client/acp_personas/kiro.py
+++ b/jupyter_ai_acp_client/acp_personas/kiro.py
@@ -181,6 +181,9 @@ class KiroAcpPersona(BaseAcpPersona):
             return True
         return await self._check_kiro_auth()
     
+    async def _on_unauthenticated(self) -> None:
+        await self.handle_no_auth(None)
+
     async def handle_no_auth(self, message: Message | None = None) -> None:
         await super().handle_no_auth(message)
 

--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -420,7 +420,7 @@ class BaseAcpPersona(BasePersona):
 
         if not await self.is_authed():
             self.emit("acp_login", "failure")
-            raise _NotAuthenticated()
+            await self._on_unauthenticated()
 
         self.emit_once("acp_login")
 
@@ -454,6 +454,12 @@ class BaseAcpPersona(BasePersona):
             raise
 
         self.emit_once("acp_success")
+
+    async def _on_unauthenticated(self) -> None:
+        """
+        Called by `prepare()` when the auth pre-check (`is_authed()`) fails.
+        """
+        raise _NotAuthenticated()
 
     def _discard_failed_startup(self) -> None:
         """

--- a/jupyter_ai_acp_client/tests/test_base_acp_persona.py
+++ b/jupyter_ai_acp_client/tests/test_base_acp_persona.py
@@ -817,3 +817,66 @@ class TestFunnelEvents:
 
 
 
+
+
+class TestOnUnauthenticated:
+    """
+    The `_on_unauthenticated()` seam `prepare()` calls when `is_authed()` is
+    False. The base default fast-fails (raise `_NotAuthenticated`); a persona
+    that waits for sign-in (e.g. Kiro) overrides it to prompt-and-return so
+    `prepare()` proceeds into its wait instead of ending. See the Kiro
+    auto-resume-after-login fix.
+    """
+
+    async def test_base_default_raises_not_authenticated(self):
+        """The base seam preserves the fast-fail contract."""
+        cls, persona = _make_lazy_persona()
+
+        with pytest.raises(_NotAuthenticated):
+            await persona._on_unauthenticated()
+
+    async def test_prepare_fast_fails_when_seam_raises(self):
+        """With the default seam, an unauthenticated prepare() raises and spawns
+        nothing (the fast-fail path used by non-waiting agents)."""
+        cls, persona = _make_lazy_persona()
+        persona.is_authed = AsyncMock(return_value=False)
+
+        with pytest.raises(_NotAuthenticated):
+            await persona.prepare()
+
+        assert "_subprocess_future" not in cls.__dict__
+        assert persona._client_session_future is None
+
+    async def test_prepare_proceeds_when_seam_does_not_raise(self):
+        """A persona overriding `_on_unauthenticated()` to return (not raise)
+        makes prepare() continue past the auth gate and start the
+        subprocess/client/session — even though `is_authed()` is False. This is
+        the mechanism behind Kiro's wait-for-login auto-resume: prepare() stays
+        alive and completes once the agent's own wait (before_agent_subprocess)
+        resolves, rather than ending on the first no-auth check.
+        """
+        called = {"seam": 0}
+
+        class _WaitingPersona(BaseAcpPersona):
+            event_loop = None
+            event_logger = None
+
+            @property
+            def defaults(self):
+                return MagicMock()
+
+            async def _on_unauthenticated(self) -> None:
+                # Show a prompt (elided here) and return without raising.
+                called["seam"] += 1
+
+        cls, persona = _make_lazy_persona(persona_cls=_WaitingPersona)
+        persona.is_authed = AsyncMock(return_value=False)
+
+        await persona.prepare()
+
+        # The seam ran instead of raising, and startup proceeded.
+        assert called["seam"] == 1
+        assert cls._subprocess_future is not None
+        assert cls._client_future is not None
+        assert persona._client_session_future is not None
+        assert await persona.get_agent_subprocess() == "subprocess"

--- a/jupyter_ai_acp_client/tests/test_kiro.py
+++ b/jupyter_ai_acp_client/tests/test_kiro.py
@@ -43,6 +43,7 @@ from jupyter_ai_acp_client.kiro_client import (
     KiroModelOption,
     KiroModels,
 )
+from jupyter_ai_acp_client.base_acp_persona import BaseAcpPersona, _NotAuthenticated
 
 _ALL_KIRO_MODELS = [
     KiroModels,
@@ -733,3 +734,36 @@ class TestKiroPersonaUpdateModel:
 class TestKiroClientInjection:
     def test_kiro_persona_uses_kiro_acp_client(self):
         assert KiroAcpPersona.acp_client_class is KiroAcpClient
+
+
+class TestKiroUnauthenticated:
+    """
+    Kiro's wait-for-login auth handling. Unlike the base persona (which
+    fast-fails by raising `_NotAuthenticated`), Kiro overrides
+    `_on_unauthenticated` to show the login prompt and *return* — so `prepare()`
+    proceeds into `before_agent_subprocess()`'s poll loop and completes once the
+    user signs in, auto-resuming even when `prepare()` was triggered by
+    selection rather than a message.
+    """
+
+    async def test_on_unauthenticated_prompts_and_does_not_raise(self):
+        persona = _kiro_persona()
+        persona.handle_no_auth = AsyncMock()
+
+        # Must NOT raise (the base default would); this is what keeps prepare()
+        # alive to wait for login instead of ending.
+        await persona._on_unauthenticated()
+
+        persona.handle_no_auth.assert_awaited_once_with(None)
+
+    async def test_on_unauthenticated_differs_from_base_fast_fail(self):
+        # The base seam raises for the same call; Kiro overrides that to wait.
+        persona = _kiro_persona()
+        persona.handle_no_auth = AsyncMock()
+
+        with pytest.raises(_NotAuthenticated):
+            await BaseAcpPersona._on_unauthenticated(persona)
+
+        # Kiro's override, by contrast, returns without raising.
+        await persona._on_unauthenticated()
+        persona.handle_no_auth.assert_awaited_once_with(None)


### PR DESCRIPTION
When a persona is selected, PersonaManager now runs prepare() on selection rather than on every message. Kiro's prepare() fast-failed by raising _NotAuthenticated when the user was not signed in, and nothing re-triggered it after the user logged in via the terminal, so the login flow no longer auto-resumed.

Introduce an overridable _on_unauthenticated() seam on BaseAcpPersona that defaults to raising _NotAuthenticated. KiroAcpPersona overrides it to show the login prompt and return without raising, restoring auto-resume.

<img width="1918" height="1034" alt="Screenshot 2026-08-26 at 8 34 37 PM" src="https://github.com/user-attachments/assets/ee0707f9-4b93-4b3e-a867-5aee40358bd6" />
