### PR TITLE
Stop agents from editing notebooks directly

### DIFF
--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -71,6 +71,14 @@ class _NotAuthenticated(Exception):
 
 
 class BaseAcpPersona(BasePersona):
+    NOTEBOOK_EDITING_GUIDANCE: ClassVar[str] = (
+        "System note: When creating or editing Jupyter notebooks (.ipynb), use "
+        "the Jupyter notebook MCP tools (for example insert_cell, edit_cell, "
+        "delete_cell, read_notebook). Do not write or edit .ipynb files directly "
+        "with generic file-write/edit tools — direct writes are blocked to "
+        "prevent notebook corruption."
+    )
+
     _before_subprocess_future: ClassVar[Task[None] | None] = None
     """
     The task that blocks the agent subprocess from starting until resolved.
@@ -168,6 +176,8 @@ class BaseAcpPersona(BasePersona):
         self._executable = executable
         self._pending_session_recovery_context: bool = False
         self._was_initially_unauthenticated: bool = False
+        # Whether this session's notebook guidance was injected yet.
+        self._notebook_guidance_sent: bool = False
         self._emitted: set[str] = set()
         self._client_session_future: Task[
             NewSessionResponse | LoadSessionResponse
@@ -579,6 +589,11 @@ class BaseAcpPersona(BasePersona):
         client = await self.get_client()
         session_id = await self.get_session_id()
         prompt = message.body.strip()
+
+        # Inject notebook guidance once per session.
+        if not self._notebook_guidance_sent:
+            self._notebook_guidance_sent = True
+            prompt = self.NOTEBOOK_EDITING_GUIDANCE + "\n\n" + prompt
 
         if self._pending_session_recovery_context:
             self._pending_session_recovery_context = False

--- a/jupyter_ai_acp_client/default_acp_client.py
+++ b/jupyter_ai_acp_client/default_acp_client.py
@@ -503,6 +503,35 @@ class JaiAcpClient(Client):
         """Returns the list of active session IDs managed by this client."""
         return list(self._personas_by_session.keys())
 
+    @staticmethod
+    def _is_direct_notebook_write(tool_call: ToolCall, persona: BasePersona) -> bool:
+        """True if the tool call directly writes/edits an ``.ipynb``.
+
+        Blocks the corrupting path; exempts notebook MCP tools (titled
+        ``Running: @<server>/<tool>``), which are the safe way to edit.
+        """
+        def _is_ipynb(path: object) -> bool:
+            return isinstance(path, str) and Path(path).suffix == ".ipynb"
+
+        # Exempt MCP tool calls.
+        if (tool_call.title or "").startswith("Running: @"):
+            return False
+
+        raw_input = tool_call.raw_input if isinstance(tool_call.raw_input, dict) else {}
+
+        # Target path may appear in locations, raw_input path keys, or diffs.
+        for location in (tool_call.locations or []):
+            if _is_ipynb(getattr(location, "path", location)):
+                return True
+        for key in ("path", "file_path", "filepath", "filePath"):
+            if _is_ipynb(raw_input.get(key)):
+                return True
+
+        root_dir = persona.parent.root_dir
+        diffs = extract_diffs(tool_call.content, root_dir=root_dir) or \
+            extract_diffs_from_raw_input(raw_input, root_dir=root_dir)
+        return any(_is_ipynb(d.path) for d in (diffs or []))
+
     async def request_permission(
         self, options: list[PermissionOption], session_id: str, tool_call: ToolCall, **kwargs: Any
     ) -> RequestPermissionResponse:
@@ -523,6 +552,22 @@ class JaiAcpClient(Client):
                 f"options={[{'id': o.option_id, 'name': o.name, 'kind': o.kind} for o in options]} "
                 f"persona_class={persona.__class__.__name__}"
             )
+
+            # Block direct .ipynb writes; MCP notebook tools are exempt.
+            if self._is_direct_notebook_write(tool_call, persona):
+                persona.log.info(
+                    "request_permission: DENIED direct notebook write; "
+                    f"tool_call_id={tool_call.tool_call_id}"
+                )
+                persona.send_message(
+                    "⚠️ Direct edits to notebook (`.ipynb`) files are blocked to "
+                    "prevent corruption. Please edit the notebook using the "
+                    "Jupyter notebook MCP tools (for example `insert_cell` / "
+                    "`edit_cell`) instead of writing the file directly."
+                )
+                return RequestPermissionResponse(
+                    outcome=DeniedOutcome(outcome="cancelled")
+                )
 
             permission_options = list(options)
 

--- a/jupyter_ai_acp_client/default_acp_client.py
+++ b/jupyter_ai_acp_client/default_acp_client.py
@@ -503,35 +503,6 @@ class JaiAcpClient(Client):
         """Returns the list of active session IDs managed by this client."""
         return list(self._personas_by_session.keys())
 
-    @staticmethod
-    def _is_direct_notebook_write(tool_call: ToolCall, persona: BasePersona) -> bool:
-        """True if the tool call directly writes/edits an ``.ipynb``.
-
-        Blocks the corrupting path; exempts notebook MCP tools (titled
-        ``Running: @<server>/<tool>``), which are the safe way to edit.
-        """
-        def _is_ipynb(path: object) -> bool:
-            return isinstance(path, str) and Path(path).suffix == ".ipynb"
-
-        # Exempt MCP tool calls.
-        if (tool_call.title or "").startswith("Running: @"):
-            return False
-
-        raw_input = tool_call.raw_input if isinstance(tool_call.raw_input, dict) else {}
-
-        # Target path may appear in locations, raw_input path keys, or diffs.
-        for location in (tool_call.locations or []):
-            if _is_ipynb(getattr(location, "path", location)):
-                return True
-        for key in ("path", "file_path", "filepath", "filePath"):
-            if _is_ipynb(raw_input.get(key)):
-                return True
-
-        root_dir = persona.parent.root_dir
-        diffs = extract_diffs(tool_call.content, root_dir=root_dir) or \
-            extract_diffs_from_raw_input(raw_input, root_dir=root_dir)
-        return any(_is_ipynb(d.path) for d in (diffs or []))
-
     async def request_permission(
         self, options: list[PermissionOption], session_id: str, tool_call: ToolCall, **kwargs: Any
     ) -> RequestPermissionResponse:
@@ -552,22 +523,6 @@ class JaiAcpClient(Client):
                 f"options={[{'id': o.option_id, 'name': o.name, 'kind': o.kind} for o in options]} "
                 f"persona_class={persona.__class__.__name__}"
             )
-
-            # Block direct .ipynb writes; MCP notebook tools are exempt.
-            if self._is_direct_notebook_write(tool_call, persona):
-                persona.log.info(
-                    "request_permission: DENIED direct notebook write; "
-                    f"tool_call_id={tool_call.tool_call_id}"
-                )
-                persona.send_message(
-                    "⚠️ Direct edits to notebook (`.ipynb`) files are blocked to "
-                    "prevent corruption. Please edit the notebook using the "
-                    "Jupyter notebook MCP tools (for example `insert_cell` / "
-                    "`edit_cell`) instead of writing the file directly."
-                )
-                return RequestPermissionResponse(
-                    outcome=DeniedOutcome(outcome="cancelled")
-                )
 
             permission_options = list(options)
 
@@ -642,6 +597,18 @@ class JaiAcpClient(Client):
             raise RequestError.invalid_params({"path": "path cannot be empty"})
 
         file_path = Path(path)
+
+        # Block direct notebook writes.
+        if file_path.suffix == ".ipynb":
+            raise RequestError.invalid_params(
+                {
+                    "path": (
+                        "writing .ipynb files directly is not allowed; use the "
+                        "Jupyter notebook MCP tools (e.g. insert_cell, edit_cell) "
+                        "instead"
+                    )
+                }
+            )
 
         # Check if path is a directory
         if file_path.is_dir():

--- a/jupyter_ai_acp_client/tests/test_base_acp_persona.py
+++ b/jupyter_ai_acp_client/tests/test_base_acp_persona.py
@@ -133,6 +133,40 @@ class TestProcessMessageAttachments:
             root_dir="/home/user/notebooks",
         )
 
+    async def test_notebook_guidance_prepended_on_first_message(self):
+        """The first message of a session is prefixed with the agent-agnostic
+        notebook-editing guidance, then the flag flips so it isn't repeated."""
+        client = _make_client()
+        persona = _make_persona()
+        persona.get_client.return_value = client
+        persona._notebook_guidance_sent = False  # simulate a fresh session
+        msg = _make_message("@bot add a cell")
+
+        await BaseAcpPersona.process_message(persona, msg)
+
+        sent_prompt = client.prompt_and_reply.call_args.kwargs["prompt"]
+        assert sent_prompt.startswith(BaseAcpPersona.NOTEBOOK_EDITING_GUIDANCE)
+        assert sent_prompt.endswith("@bot add a cell")
+        # Flag flipped so subsequent messages don't repeat the guidance.
+        assert persona._notebook_guidance_sent is True
+
+    async def test_notebook_guidance_not_repeated(self):
+        """Once guidance has been sent, later messages are passed through as-is."""
+        client = _make_client()
+        persona = _make_persona()
+        persona.get_client.return_value = client
+        persona._notebook_guidance_sent = True  # already sent earlier this session
+        msg = _make_message("@bot another request")
+
+        await BaseAcpPersona.process_message(persona, msg)
+
+        client.prompt_and_reply.assert_called_once_with(
+            session_id="sess-1",
+            prompt="@bot another request",
+            attachments=None,
+            root_dir="/home/user/notebooks",
+        )
+
     async def test_single_attachment(self):
         """A single known attachment ID resolves to a dict."""
         client = _make_client()

--- a/jupyter_ai_acp_client/tests/test_default_acp_client.py
+++ b/jupyter_ai_acp_client/tests/test_default_acp_client.py
@@ -12,12 +12,8 @@ from acp.schema import (
     AvailableCommandsUpdate,
     ConfigOptionUpdate,
     CurrentModeUpdate,
-    DeniedOutcome,
-    FileEditToolCallContent,
     ResourceContentBlock,
     TextContentBlock,
-    ToolCall,
-    ToolCallLocation,
     Usage,
     UsageUpdate,
 )
@@ -415,161 +411,31 @@ class TestLoadSessionCleanup:
         assert "stale-session-id" not in client._loading_sessions
 
 
-def _tool_call(**kwargs) -> ToolCall:
-    """Build a ToolCall with sensible defaults for permission tests."""
-    kwargs.setdefault("tool_call_id", "tc-1")
-    kwargs.setdefault("title", "Edit")
-    return ToolCall(**kwargs)
+class TestWriteTextFileNotebookGuard:
+    """write_text_file refuses direct writes to .ipynb files (notebooks must be
+    edited via the notebook MCP tools), while other files write normally."""
 
+    async def test_write_to_notebook_is_rejected(self, tmp_path):
+        client, _, _ = _make_client_and_persona()
+        nb_path = str(tmp_path / "analysis.ipynb")
 
-class TestRequestPermissionNotebookGuard:
-    """request_permission auto-denies any tool call that targets a Jupyter
-    notebook (.ipynb), regardless of which agent sent it or which field
-    exposes the path. Notebook edits must go through notebook MCP tools."""
+        with pytest.raises(RequestError) as exc_info:
+            await client.write_text_file(
+                content='{"cells": []}', path=nb_path, session_id=SESSION_ID
+            )
 
-    def _client_and_persona(self, root_dir="/work"):
-        client, _, persona = _make_client_and_persona()
-        # request_permission reads persona.parent.root_dir when extracting diffs.
-        persona.parent.root_dir = root_dir
-        # A real logger avoids MagicMock noise but isn't required.
-        persona.log = logging.getLogger("test")
-        return client, persona
+        assert exc_info.value.code == -32602  # invalid_params
+        assert "MCP tools" in str(exc_info.value.data)
+        # The notebook file must not have been created.
+        assert not (tmp_path / "analysis.ipynb").exists()
 
-    async def test_denies_when_locations_has_ipynb(self):
-        client, persona = self._client_and_persona()
-        client._personas_by_session = {SESSION_ID: persona}
-        persona.send_message = MagicMock()
-        tool_call = _tool_call(
-            kind="edit",
-            locations=[ToolCallLocation(path="/work/analysis.ipynb")],
+    async def test_write_to_non_notebook_still_succeeds(self, tmp_path):
+        client, _, _ = _make_client_and_persona()
+        txt_path = tmp_path / "notes.txt"
+
+        result = await client.write_text_file(
+            content="hello", path=str(txt_path), session_id=SESSION_ID
         )
 
-        resp = await client.request_permission(
-            options=[], session_id=SESSION_ID, tool_call=tool_call
-        )
-
-        assert isinstance(resp.outcome, DeniedOutcome)
-        # No permission prompt should have been created for the user.
-        client._permission_manager.create_request.assert_not_called()
-        # The user is told why it was blocked (better UX than a silent hang).
-        persona.send_message.assert_called_once()
-        assert "MCP tools" in persona.send_message.call_args[0][0]
-
-    async def test_denies_when_edit_content_targets_ipynb(self):
-        client, persona = self._client_and_persona()
-        client._personas_by_session = {SESSION_ID: persona}
-        tool_call = _tool_call(
-            kind="edit",
-            content=[
-                FileEditToolCallContent(
-                    type="diff",
-                    path="/work/notebook.ipynb",
-                    new_text='{"cells": []}',
-                )
-            ],
-        )
-
-        resp = await client.request_permission(
-            options=[], session_id=SESSION_ID, tool_call=tool_call
-        )
-
-        assert isinstance(resp.outcome, DeniedOutcome)
-        client._permission_manager.create_request.assert_not_called()
-
-    async def test_denies_when_raw_input_diff_targets_ipynb(self):
-        client, persona = self._client_and_persona()
-        client._personas_by_session = {SESSION_ID: persona}
-        # Agents like OpenCode send a unified diff string in raw_input.
-        tool_call = _tool_call(
-            kind="edit",
-            raw_input={
-                "filepath": "/work/model.ipynb",
-                "diff": "@@ -1 +1 @@\n-old\n+new\n",
-            },
-        )
-
-        resp = await client.request_permission(
-            options=[], session_id=SESSION_ID, tool_call=tool_call
-        )
-
-        assert isinstance(resp.outcome, DeniedOutcome)
-        client._permission_manager.create_request.assert_not_called()
-
-    async def test_denies_when_raw_input_path_targets_ipynb(self):
-        """Kiro's direct file tools (strReplace / fsWrite) expose the target as
-        raw_input['path'] with no locations/content — the real e2e shape."""
-        client, persona = self._client_and_persona()
-        client._personas_by_session = {SESSION_ID: persona}
-        tool_call = _tool_call(
-            kind=None,
-            locations=None,
-            content=None,
-            raw_input={
-                "command": "strReplace",
-                "path": "/work/for_loop_examples.ipynb",
-                "oldStr": "a",
-                "newStr": "b",
-            },
-        )
-
-        resp = await client.request_permission(
-            options=[], session_id=SESSION_ID, tool_call=tool_call
-        )
-
-        assert isinstance(resp.outcome, DeniedOutcome)
-        client._permission_manager.create_request.assert_not_called()
-
-    async def test_non_notebook_edit_is_not_denied_by_guard(self):
-        """A .py edit must fall through to the normal permission flow, not be
-        auto-denied by the notebook guard."""
-        client, persona = self._client_and_persona()
-        client._personas_by_session = {SESSION_ID: persona}
-        # Make the permission flow resolve immediately as "denied/cancelled"
-        # via a completed future, so we can tell the guard did NOT short-circuit
-        # (create_request must be called).
-        fut = asyncio.get_running_loop().create_future()
-        fut.set_result(None)  # user cancelled → distinguishable from guard deny
-        client._permission_manager.create_request = MagicMock(return_value=fut)
-        client._tool_call_manager = MagicMock()
-
-        tool_call = _tool_call(
-            kind="edit",
-            locations=[ToolCallLocation(path="/work/script.py")],
-        )
-
-        await client.request_permission(
-            options=[], session_id=SESSION_ID, tool_call=tool_call
-        )
-
-        # The guard let it through to the normal flow.
-        client._permission_manager.create_request.assert_called_once()
-
-    async def test_mcp_notebook_tool_is_not_denied(self):
-        """MCP notebook tools (titled 'Running: @<server>/<tool>') are the safe
-        path and must NOT be denied, even though they reference an .ipynb."""
-        client, persona = self._client_and_persona()
-        client._personas_by_session = {SESSION_ID: persona}
-        fut = asyncio.get_running_loop().create_future()
-        fut.set_result(None)
-        client._permission_manager.create_request = MagicMock(return_value=fut)
-        client._tool_call_manager = MagicMock()
-
-        # Real shape from the logs: MCP insert_cell, path in raw_input.file_path.
-        tool_call = _tool_call(
-            title="Running: @Jupyter MCP Server/insert_cell",
-            kind=None,
-            locations=None,
-            content=None,
-            raw_input={
-                "file_path": "/work/for_loop_examples.ipynb",
-                "cell_type": "code",
-                "content": "print('hi')",
-            },
-        )
-
-        await client.request_permission(
-            options=[], session_id=SESSION_ID, tool_call=tool_call
-        )
-
-        # Not denied by the guard — normal permission flow was used.
-        client._permission_manager.create_request.assert_called_once()
+        assert result is not None
+        assert txt_path.read_text(encoding="utf-8") == "hello"

--- a/jupyter_ai_acp_client/tests/test_default_acp_client.py
+++ b/jupyter_ai_acp_client/tests/test_default_acp_client.py
@@ -12,8 +12,12 @@ from acp.schema import (
     AvailableCommandsUpdate,
     ConfigOptionUpdate,
     CurrentModeUpdate,
+    DeniedOutcome,
+    FileEditToolCallContent,
     ResourceContentBlock,
     TextContentBlock,
+    ToolCall,
+    ToolCallLocation,
     Usage,
     UsageUpdate,
 )
@@ -409,3 +413,163 @@ class TestLoadSessionCleanup:
             await client.load_session(persona, "stale-session-id")
 
         assert "stale-session-id" not in client._loading_sessions
+
+
+def _tool_call(**kwargs) -> ToolCall:
+    """Build a ToolCall with sensible defaults for permission tests."""
+    kwargs.setdefault("tool_call_id", "tc-1")
+    kwargs.setdefault("title", "Edit")
+    return ToolCall(**kwargs)
+
+
+class TestRequestPermissionNotebookGuard:
+    """request_permission auto-denies any tool call that targets a Jupyter
+    notebook (.ipynb), regardless of which agent sent it or which field
+    exposes the path. Notebook edits must go through notebook MCP tools."""
+
+    def _client_and_persona(self, root_dir="/work"):
+        client, _, persona = _make_client_and_persona()
+        # request_permission reads persona.parent.root_dir when extracting diffs.
+        persona.parent.root_dir = root_dir
+        # A real logger avoids MagicMock noise but isn't required.
+        persona.log = logging.getLogger("test")
+        return client, persona
+
+    async def test_denies_when_locations_has_ipynb(self):
+        client, persona = self._client_and_persona()
+        client._personas_by_session = {SESSION_ID: persona}
+        persona.send_message = MagicMock()
+        tool_call = _tool_call(
+            kind="edit",
+            locations=[ToolCallLocation(path="/work/analysis.ipynb")],
+        )
+
+        resp = await client.request_permission(
+            options=[], session_id=SESSION_ID, tool_call=tool_call
+        )
+
+        assert isinstance(resp.outcome, DeniedOutcome)
+        # No permission prompt should have been created for the user.
+        client._permission_manager.create_request.assert_not_called()
+        # The user is told why it was blocked (better UX than a silent hang).
+        persona.send_message.assert_called_once()
+        assert "MCP tools" in persona.send_message.call_args[0][0]
+
+    async def test_denies_when_edit_content_targets_ipynb(self):
+        client, persona = self._client_and_persona()
+        client._personas_by_session = {SESSION_ID: persona}
+        tool_call = _tool_call(
+            kind="edit",
+            content=[
+                FileEditToolCallContent(
+                    type="diff",
+                    path="/work/notebook.ipynb",
+                    new_text='{"cells": []}',
+                )
+            ],
+        )
+
+        resp = await client.request_permission(
+            options=[], session_id=SESSION_ID, tool_call=tool_call
+        )
+
+        assert isinstance(resp.outcome, DeniedOutcome)
+        client._permission_manager.create_request.assert_not_called()
+
+    async def test_denies_when_raw_input_diff_targets_ipynb(self):
+        client, persona = self._client_and_persona()
+        client._personas_by_session = {SESSION_ID: persona}
+        # Agents like OpenCode send a unified diff string in raw_input.
+        tool_call = _tool_call(
+            kind="edit",
+            raw_input={
+                "filepath": "/work/model.ipynb",
+                "diff": "@@ -1 +1 @@\n-old\n+new\n",
+            },
+        )
+
+        resp = await client.request_permission(
+            options=[], session_id=SESSION_ID, tool_call=tool_call
+        )
+
+        assert isinstance(resp.outcome, DeniedOutcome)
+        client._permission_manager.create_request.assert_not_called()
+
+    async def test_denies_when_raw_input_path_targets_ipynb(self):
+        """Kiro's direct file tools (strReplace / fsWrite) expose the target as
+        raw_input['path'] with no locations/content — the real e2e shape."""
+        client, persona = self._client_and_persona()
+        client._personas_by_session = {SESSION_ID: persona}
+        tool_call = _tool_call(
+            kind=None,
+            locations=None,
+            content=None,
+            raw_input={
+                "command": "strReplace",
+                "path": "/work/for_loop_examples.ipynb",
+                "oldStr": "a",
+                "newStr": "b",
+            },
+        )
+
+        resp = await client.request_permission(
+            options=[], session_id=SESSION_ID, tool_call=tool_call
+        )
+
+        assert isinstance(resp.outcome, DeniedOutcome)
+        client._permission_manager.create_request.assert_not_called()
+
+    async def test_non_notebook_edit_is_not_denied_by_guard(self):
+        """A .py edit must fall through to the normal permission flow, not be
+        auto-denied by the notebook guard."""
+        client, persona = self._client_and_persona()
+        client._personas_by_session = {SESSION_ID: persona}
+        # Make the permission flow resolve immediately as "denied/cancelled"
+        # via a completed future, so we can tell the guard did NOT short-circuit
+        # (create_request must be called).
+        fut = asyncio.get_running_loop().create_future()
+        fut.set_result(None)  # user cancelled → distinguishable from guard deny
+        client._permission_manager.create_request = MagicMock(return_value=fut)
+        client._tool_call_manager = MagicMock()
+
+        tool_call = _tool_call(
+            kind="edit",
+            locations=[ToolCallLocation(path="/work/script.py")],
+        )
+
+        await client.request_permission(
+            options=[], session_id=SESSION_ID, tool_call=tool_call
+        )
+
+        # The guard let it through to the normal flow.
+        client._permission_manager.create_request.assert_called_once()
+
+    async def test_mcp_notebook_tool_is_not_denied(self):
+        """MCP notebook tools (titled 'Running: @<server>/<tool>') are the safe
+        path and must NOT be denied, even though they reference an .ipynb."""
+        client, persona = self._client_and_persona()
+        client._personas_by_session = {SESSION_ID: persona}
+        fut = asyncio.get_running_loop().create_future()
+        fut.set_result(None)
+        client._permission_manager.create_request = MagicMock(return_value=fut)
+        client._tool_call_manager = MagicMock()
+
+        # Real shape from the logs: MCP insert_cell, path in raw_input.file_path.
+        tool_call = _tool_call(
+            title="Running: @Jupyter MCP Server/insert_cell",
+            kind=None,
+            locations=None,
+            content=None,
+            raw_input={
+                "file_path": "/work/for_loop_examples.ipynb",
+                "cell_type": "code",
+                "content": "print('hi')",
+            },
+        )
+
+        await client.request_permission(
+            options=[], session_id=SESSION_ID, tool_call=tool_call
+        )
+
+        # Not denied by the guard — normal permission flow was used.
+        client._permission_manager.create_request.assert_called_once()


### PR DESCRIPTION
ACP agents editing .ipynb files directly can corrupt the notebook JSON and bypass the live document model.
Issue https://github.com/jupyter-ai-contrib/jupyter-ai-acp-client/issues/183
  
Fix:
  
  - Prepend NOTEBOOK_EDITING_GUIDANCE once per session to the prompt in BaseAcpPersona.process_message, instructing any agent to use the notebook MCP tools and not write .ipynb directly. 
  
  - JaiAcpClient.request_permission denies a direct .ipynb write if an agent attempts one anyway. 
  
  
<img width="1911" height="1041" alt="Screenshot 2026-08-26 at 9 26 55 PM" src="https://github.com/user-attachments/assets/5a35c78e-100a-4adf-a321-d97acff4c6b3" />
<img width="876" height="844" alt="Screenshot 2026-08-26 at 10 10 59 PM" src="https://github.com/user-attachments/assets/b598dbe6-8089-4581-9ea9-90e4a301de46" />

