### PR TITLE
Bump chat and persona-manager to latest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,8 @@ classifiers = [
 ]
 dependencies = [
     "jupyter_server>=2.4.0,<3",
-    "jupyter_ai_persona_manager>=0.2.0a3",
-    "jupyterlab_chat>=0.25.0a1",
+    "jupyter_ai_persona_manager>=0.2.0rc0",
+    "jupyterlab_chat>=0.25.0rc0",
     "agent_client_protocol>=0.11.0,<0.12.0",
     "pydantic>=2,<3",
 ]


### PR DESCRIPTION
## Motivation

`jupyterlab_chat` 0.25.0rc0 and `jupyter_ai_persona_manager` 0.2.0rc0 are now published on PyPI. This bumps the dependency floors from the earlier alpha pins so the ACP client resolves against the release candidates.

## Changes

- `jupyter_ai_persona_manager>=0.2.0a3` → `>=0.2.0rc0`
- `jupyterlab_chat>=0.25.0a1` → `>=0.25.0rc0`