### PR TITLE
Add server-side prompt context providers for ACP personas

### DIFF
--- a/docs/source/developers/index.md
+++ b/docs/source/developers/index.md
@@ -1,0 +1,53 @@
+# jupyter-ai-acp-client
+
+## Additional prompt context
+
+Extensions can add context to ACP prompts without changing the user's message
+body or inserting messages into the conversation. Register a server-side callable
+through a Python entry point:
+
+```toml
+[project.entry-points."jupyter_ai_acp_client.prompt_context"]
+example = "example_extension.context:prompt_context"
+```
+
+```python
+import json
+
+
+def prompt_context(message, history):
+    if message is None:
+        return None
+    project = (message.metadata or {}).get("example_project")
+    if not isinstance(project, str):
+        return None
+    return f"Attached project: {json.dumps(project)}"
+```
+
+`prompt_context(message, history)` may be synchronous or asynchronous. It returns
+text, or `None`/empty text when the extension does not apply. Both arguments are
+independent deep copies of chat messages. `history` excludes deleted messages;
+it may contain the current message. `message` is `None` for the automatic prompt
+after an agent signs in, so providers with conversation-level bindings should
+recover those from history. Validate persisted metadata before using it.
+
+Providers are loaded once per server process and called in entry-point name
+order for each normal prompt, including session recovery, and for the automatic
+post-authentication prompt. Duplicate names, loading errors, invalid results and
+provider exceptions stop the prompt through the persona's normal error handling;
+required context is never silently omitted. Install/update providers and restart
+the Jupyter server to change the registry.
+
+Returned text is appended to the outgoing prompt as additional **user context**,
+not as a system-role message. User-authored text, mentions, attachments and chat
+metadata stay unchanged. Context is not rendered, copied or edited as part of the
+chat message, though an agent may refer to it in its response. Providers should
+not return secrets and should return nothing for unrelated chats. Only installed
+server packages can register providers; metadata cannot name executable providers.
+
+This API applies to personas using `BaseAcpPersona.process_message`. Custom
+personas which replace that method can call
+`jupyter_ai_acp_client.prompt_context.get_prompt_context(message, history)`
+explicitly before constructing their own agent prompt. The module exports
+`PROMPT_CONTEXT_API_VERSION = 1` and `get_prompt_context_providers()` for hosts
+that need to verify support and registration before accepting a message.

--- a/jupyter_ai_acp_client/base_acp_persona.py
+++ b/jupyter_ai_acp_client/base_acp_persona.py
@@ -29,6 +29,7 @@ from jupyter_ai_persona_manager import Usage as AwarenessUsage
 from jupyterlab_chat.models import FileAttachment, Message, NotebookAttachment
 
 from .default_acp_client import JaiAcpClient
+from .prompt_context import get_prompt_context
 from .telemetry import emit_event, auto_emit_event
 
 # A single session config option the agent advertises: either a select (one of
@@ -376,6 +377,7 @@ class BaseAcpPersona(BasePersona):
         After the user signs in, send a hidden prompt with chat history and a
         prescribed message template for the agent to follow.
         """
+        context = await get_prompt_context(None, self.chat.get_messages())
         history = self._build_history_context(
             preamble=(
                 "You just became available after the user signed in. "
@@ -396,6 +398,8 @@ class BaseAcpPersona(BasePersona):
                 "\"I'm logged in now and ready to help. What can I do for you?\""
             )
 
+        if context:
+            prompt += "\n\n" + context
         await client.prompt_and_reply(
             session_id=session_id,
             prompt=prompt,
@@ -592,6 +596,7 @@ class BaseAcpPersona(BasePersona):
             await self._resume_after_auth(client, session_id)
             return
 
+        context = await get_prompt_context(message, self.chat.get_messages())
         client = await self.get_client()
         session_id = await self.get_session_id()
         prompt = message.body.strip()
@@ -626,6 +631,8 @@ class BaseAcpPersona(BasePersona):
                 resolved.append(raw)
             attachments = resolved or None
 
+        if context:
+            prompt += "\n\n" + context
         await client.prompt_and_reply(
             session_id=session_id,
             prompt=prompt,

--- a/jupyter_ai_acp_client/prompt_context.py
+++ b/jupyter_ai_acp_client/prompt_context.py
@@ -1,0 +1,59 @@
+"""Extension-provided context sent to ACP without changing chat messages."""
+
+from copy import deepcopy
+from functools import lru_cache
+from importlib.metadata import entry_points
+from inspect import isawaitable
+from collections.abc import Awaitable, Callable, Sequence
+
+from jupyterlab_chat.models import Message
+
+PROMPT_CONTEXT_API_VERSION = 1
+ENTRY_POINT_GROUP = "jupyter_ai_acp_client.prompt_context"
+PromptContextProvider = Callable[
+    [Message | None, Sequence[Message]], str | None | Awaitable[str | None]
+]
+
+
+@lru_cache(maxsize=1)
+def get_prompt_context_providers() -> dict[str, PromptContextProvider]:
+    """Load installed providers once per process, ordered by entry-point name."""
+    providers = {}
+    for entry in sorted(entry_points(group=ENTRY_POINT_GROUP), key=lambda e: e.name):
+        if entry.name in providers:
+            raise ValueError(f"Duplicate prompt context provider: {entry.name}")
+        provider = entry.load()
+        if not callable(provider):
+            raise TypeError(f"Prompt context provider {entry.name!r} is not callable")
+        providers[entry.name] = provider
+    return providers
+
+
+async def get_prompt_context(
+    message: Message | None, history: Sequence[Message]
+) -> str:
+    """Collect additional prompt text from server-installed providers.
+
+    Providers receive independent snapshots, not the mutable chat model.
+    ``message`` is None for the automatic prompt after agent authentication.
+    Deleted messages are excluded from history. Return None/empty text for
+    unrelated conversations. Errors abort the prompt through the persona's
+    usual error handling rather than silently dropping required context.
+    This text is additional user context, not a system-role instruction.
+    """
+    parts = []
+    history = tuple(item for item in history if not item.deleted)
+    for name, provider in get_prompt_context_providers().items():
+        try:
+            result = provider(deepcopy(message), deepcopy(history))
+            if isawaitable(result):
+                result = await result
+            if result is not None and not isinstance(result, str):
+                raise TypeError("Expected a string or None")
+            if result and result.strip():
+                parts.append(result.strip())
+        except Exception as error:
+            raise ValueError(
+                f"Prompt context provider {name!r} failed: {error}"
+            ) from error
+    return "\n\n".join(parts)

--- a/jupyter_ai_acp_client/tests/test_prompt_context.py
+++ b/jupyter_ai_acp_client/tests/test_prompt_context.py
@@ -1,0 +1,130 @@
+"""Prompt-only extension context, including isolation and failure behavior."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from jupyterlab_chat.models import Message
+
+from jupyter_ai_acp_client import prompt_context
+from jupyter_ai_acp_client.base_acp_persona import BaseAcpPersona
+from .test_base_acp_persona import _make_persona
+
+
+def message(body="Question", metadata=None, **kwargs):
+    return Message(
+        id="request", body=body, sender="user", time=0, metadata=metadata, **kwargs
+    )
+
+
+async def test_sync_async_providers_receive_independent_snapshots(monkeypatch):
+    original = message(metadata={"project": "example"})
+    history = [original, message(deleted=True)]
+
+    def first(current, previous):
+        assert len(previous) == 1
+        current.body = "mutated"
+        previous[0].metadata["project"] = "mutated"
+        return "First context"
+
+    async def second(current, previous):
+        assert current.body == "Question"
+        assert previous[0].metadata == {"project": "example"}
+        return "Second context"
+
+    monkeypatch.setattr(
+        prompt_context,
+        "get_prompt_context_providers",
+        lambda: {
+            "first": first,
+            "second": second,
+            "unrelated": lambda m, h: None,
+        },
+    )
+    assert (
+        await prompt_context.get_prompt_context(original, history)
+        == "First context\n\nSecond context"
+    )
+    assert original.body == "Question"
+    assert original.metadata == {"project": "example"}
+
+
+@pytest.mark.parametrize("result", [None, "", "   "])
+async def test_unrelated_context_is_omitted(monkeypatch, result):
+    monkeypatch.setattr(
+        prompt_context,
+        "get_prompt_context_providers",
+        lambda: {
+            "unrelated": lambda m, h: result,
+        },
+    )
+    assert await prompt_context.get_prompt_context(message(), []) == ""
+
+
+@pytest.mark.parametrize("broken", [lambda m, h: 42, lambda m, h: 1 / 0])
+async def test_provider_errors_abort_prompt(monkeypatch, broken):
+    monkeypatch.setattr(
+        prompt_context, "get_prompt_context_providers", lambda: {"broken": broken}
+    )
+    persona = _make_persona()
+    with pytest.raises(ValueError, match="provider 'broken' failed"):
+        await BaseAcpPersona.process_message(persona, message())
+    persona.get_client.assert_not_awaited()
+
+
+@pytest.mark.parametrize("recover", [False, True])
+async def test_context_reaches_agent_on_each_turn_without_changing_chat(
+    monkeypatch, recover
+):
+    provider = MagicMock(return_value="Project context")
+    monkeypatch.setattr(
+        prompt_context, "get_prompt_context_providers", lambda: {"example": provider}
+    )
+    persona = _make_persona()
+    persona._pending_session_recovery_context = recover
+    persona._build_history_context.return_value = "Earlier conversation"
+    client = persona.get_client.return_value
+    client.prompt_and_reply = AsyncMock()
+    current = message(metadata={"example": {"project": "one"}})
+    for _ in range(2):
+        await BaseAcpPersona.process_message(persona, current)
+        sent = client.prompt_and_reply.call_args.kwargs["prompt"]
+        assert sent.count("Project context") == 1
+        assert sent.endswith("Question\n\nProject context")
+    assert current.body == "Question"
+    assert current.metadata == {"example": {"project": "one"}}
+    assert provider.call_count == 2
+    persona.chat.add_message.assert_not_called()
+
+
+async def test_authentication_resume_also_receives_context(monkeypatch):
+    provider = MagicMock(return_value="Restored project")
+    monkeypatch.setattr(
+        prompt_context, "get_prompt_context_providers", lambda: {"example": provider}
+    )
+    persona = _make_persona()
+    persona._build_history_context.return_value = "Original question"
+    client = AsyncMock()
+    await BaseAcpPersona._resume_after_auth(persona, client, "session")
+    assert client.prompt_and_reply.call_args.kwargs["prompt"].endswith(
+        "Restored project"
+    )
+    assert provider.call_args.args[0] is None
+
+
+def test_entry_point_order_and_validation(monkeypatch):
+    a, b = MagicMock(), MagicMock()
+    a.name, b.name = "a", "b"
+    a.load.return_value, b.load.return_value = lambda m, h: "A", lambda m, h: "B"
+    monkeypatch.setattr(prompt_context, "entry_points", lambda **kw: [b, a])
+    prompt_context.get_prompt_context_providers.cache_clear()
+    try:
+        assert list(prompt_context.get_prompt_context_providers()) == ["a", "b"]
+        a.load.assert_called_once()
+        prompt_context.get_prompt_context_providers()
+        a.load.assert_called_once()
+        prompt_context.get_prompt_context_providers.cache_clear()
+        b.name = "a"
+        with pytest.raises(ValueError, match="Duplicate"):
+            prompt_context.get_prompt_context_providers()
+    finally:
+        prompt_context.get_prompt_context_providers.cache_clear()


### PR DESCRIPTION
Extensions that attach project context currently have to put it in the user message body for ACP agents to receive it. That also exposes implementation guidance in the conversation, copied messages, and the edit composer.

Add a Python entry-point API that supplies additional text only when constructing the outgoing ACP prompt. Providers receive independent snapshots of the current message and non-deleted history and can return text synchronously or asynchronously. Normal prompts, session recovery, and automatic post-authentication prompts use the same hook; saved messages and attachments stay unchanged.

Provider failures abort the prompt through existing persona error handling. The API is optional, applies to BaseAcpPersona, and has developer documentation and a capability version for consumers. Custom personas can opt in through the public helper.

Validation: all 373 Python tests pass, including new coverage for provider discovery, isolation, failure behavior, repeat turns, session recovery, and post-authentication resumption. Also exercised with a downstream Lightcone provider in JupyterLab browser tests, including persisted chats and MCP cards.

Downstream integration: https://github.com/LightconeResearch/jupyterlab-lightcone/pull/24 (draft pending this API).
